### PR TITLE
(#11) Add commandline colors

### DIFF
--- a/examples/WristIOTalonFX.java
+++ b/examples/WristIOTalonFX.java
@@ -184,7 +184,7 @@ public class WristIOTalonFX implements WristIO {
 
           Logger.recordOutput(
               "wrist/referenceSlope",
-              leadMotor.getClosedLoopReferenceSlope().getValueAsDouble());
+              wristMotor.getClosedLoopReferenceSlope().getValueAsDouble());
           outputs.wristAppliedVolts.mut_replace(
               Volts.of(wristMotor.getClosedLoopOutput().getValueAsDouble()));
           outputs.pContrib.mut_replace(

--- a/src/robotvibecoder_aidnem/constants.py
+++ b/src/robotvibecoder_aidnem/constants.py
@@ -10,3 +10,13 @@ DEFAULT_CONFIG: MechanismConfig = MechanismConfig(
     "leftMotor",
     "exampleEncoder",
 )
+
+
+class Colors:
+    fg_red = "\x1b[31m"
+    fg_green = "\x1b[32m"
+    fg_cyan = "\x1b[36m"
+    bold = "\x1b[1m"
+    reset = "\x1b[0m"
+
+    title_str = f"{fg_cyan}RobotVibeCoder{reset}"

--- a/src/robotvibecoder_aidnem/main.py
+++ b/src/robotvibecoder_aidnem/main.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from sys import argv
+from robotvibecoder_aidnem import constants
 from robotvibecoder_aidnem.config import load_json_config
 from robotvibecoder_aidnem.templating import generate_env
 from robotvibecoder_aidnem.subcommands.new import new
@@ -52,6 +53,10 @@ def main() -> None:
     args = parser.parse_args()
     # Call the default function defined by the subcommand
     args.func(args)
+
+    print(
+        f"{constants.Colors.fg_green}{constants.Colors.bold}Done.{constants.Colors.reset}"
+    )
 
 
 if __name__ == "__main__":

--- a/src/robotvibecoder_aidnem/subcommands/generate.py
+++ b/src/robotvibecoder_aidnem/subcommands/generate.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 import json
 import sys
+from robotvibecoder_aidnem import constants
 from robotvibecoder_aidnem.config import (
     MechanismConfig,
     MechanismKind,
@@ -13,8 +14,6 @@ import os
 
 
 def generate(args: Namespace) -> None:
-    print("[RobotVibeCoder] Generating a Mechanism")
-
     if args.stdin:
         print("Reading config from stdin.")
         data = json.load(sys.stdin)
@@ -27,10 +26,8 @@ def generate(args: Namespace) -> None:
             )
             sys.exit(1)
         config_path = os.path.join(args.folder, args.config)
-        print(f"[RobotVibeCoder] Reading config file at {config_path}")
+        print(f"[{constants.Colors.title_str}] Reading config file at {config_path}")
         config: MechanismConfig = load_json_config(config_path)
-
-        print("Successfully loaded config")
 
     validate_config(config)
 
@@ -49,7 +46,9 @@ def generate(args: Namespace) -> None:
     }
 
     if not args.stdin:
-        print("WARNING: This will create/overwrite files at the following paths:")
+        print(
+            f"{constants.Colors.fg_red}{constants.Colors.bold}WARNING{constants.Colors.reset}: This will create/overwrite files at the following paths:"
+        )
         for file_template in file_templates:
             output_path = os.path.join(
                 args.folder, file_templates[file_template].format(name=config.name)
@@ -61,6 +60,7 @@ def generate(args: Namespace) -> None:
             print("\nCancelled.")
             sys.exit(0)
 
+    print("Templating files:")
     for file_template in file_templates:
         output_path = os.path.join(
             args.folder, file_templates[file_template].format(name=config.name)
@@ -73,14 +73,10 @@ def generate(args: Namespace) -> None:
             )
             sys.exit(1)
 
-        print(f"Templating {output_path}")
+        print(f"{constants.Colors.fg_cyan}➜{constants.Colors.reset} {output_path}")
         template_path = file_template.format(name="Mechanism")
         template = env.get_template(template_path)
 
         output: str = template.render(config.__dict__)
-        print("Writing output... ", end="")
         with open(output_path, "w+") as outfile:
             outfile.write(output)
-        print("Done")
-
-    print("Done.")

--- a/src/robotvibecoder_aidnem/subcommands/new.py
+++ b/src/robotvibecoder_aidnem/subcommands/new.py
@@ -69,8 +69,10 @@ def new_config_interactive() -> MechanismConfig:
 def new(args: Namespace) -> None:
     config_path = os.path.join(args.folder, args.outfile)
 
-    print("[RobotVibeCoder] Creating a new config file")
-    print(f"  This will create/overwrite a file at `{config_path}`")
+    print(f"[{constants.Colors.title_str}] Creating a new config file")
+    print(
+        f"  {constants.Colors.fg_red}{constants.Colors.bold}WARNING{constants.Colors.reset}: This will create/overwrite a file at `{constants.Colors.fg_cyan}{config_path}{constants.Colors.reset}`"
+    )
     try:
         input("  Press Ctrl+C to cancel or [Enter] to continue")
     except KeyboardInterrupt:
@@ -83,6 +85,6 @@ def new(args: Namespace) -> None:
     else:
         config = constants.DEFAULT_CONFIG
 
-    print(f"[RobotVibeCoder] Writing config file at `{config_path}`")
+    print(f"[{constants.Colors.title_str}] Writing config file")
     with open(config_path, "w+") as outfile:
         json.dump(config.__dict__, fp=outfile, indent=2)

--- a/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
@@ -203,7 +203,7 @@ public class {{ name }}IOTalonFX implements {{ name }}IO {
 
           Logger.recordOutput(
               "{{ name|lowerfirst }}/referenceSlope",
-              leadMotor.getClosedLoopReferenceSlope().getValueAsDouble());
+              {{ lead_motor }}.getClosedLoopReferenceSlope().getValueAsDouble());
           outputs.{{ name|lowerfirst }}AppliedVolts.mut_replace(
               Volts.of({{ lead_motor }}.getClosedLoopOutput().getValueAsDouble()));
           outputs.pContrib.mut_replace(

--- a/src/robotvibecoder_aidnem/templating.py
+++ b/src/robotvibecoder_aidnem/templating.py
@@ -1,5 +1,7 @@
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+from robotvibecoder_aidnem import constants
+
 
 def article(word: str) -> str:
     return "an" if word[0].lower() in "aeiou" else "a"
@@ -29,7 +31,10 @@ def hash_can_id(device: str) -> str:
 
     if device not in canIdMap:
         canIdMap[device] = nextId
-        print(f"Mapped device {device} to placeholder CAN ID {nextId}")
+        print(f"  {constants.Colors.fg_green}➜{constants.Colors.reset} ", end="")
+        print(
+            f"Mapped device {constants.Colors.fg_cyan}{device}{constants.Colors.reset} to placeholder CAN ID {constants.Colors.fg_cyan}{nextId}{constants.Colors.reset}"
+        )
         nextId += 1
 
     return canIdMap[device]


### PR DESCRIPTION
- Cleans up unnecessary CLI spam
- Adds cool-looking colors to the output
- Fixes an old template bug where lead motor name was hardcoded to `leadMotor` in 1 place

The new CLI output can be seen here:

<img width="597" alt="image" src="https://github.com/user-attachments/assets/170b0bd2-ae43-4524-92ce-82087800ddad" />
