### PR TITLE
Add Mechanism template

### DIFF
--- a/examples/WristConstants.java
+++ b/examples/WristConstants.java
@@ -50,14 +50,14 @@ public final class WristConstants {
   @JSONExclude
   public final double rotorToWristEncoderRatio = 1.0; // TODO: Replace placeholder value
 
-  public final Double wristkP = 0.0;
-  public final Double wristkI = 0.0;
-  public final Double wristkD = 0.0;
+  public final Double wristKP = 0.0;
+  public final Double wristKI = 0.0;
+  public final Double wristKD = 0.0;
 
-  public final Double wristkS = 0.0;
-  public final Double wristkV = 0.0;
-  public final Double wristkA = 0.0;
-  public final Double wristkG = 0.0;
+  public final Double wristKS = 0.0;
+  public final Double wristKV = 0.0;
+  public final Double wristKA = 0.0;
+  public final Double wristKG = 0.0;
 
   /** This is a Double until coppercore JSONSync supports RotationsPerSecond */
   public final Double wristAngularCruiseVelocityRotationsPerSecond = 1.0;
@@ -79,7 +79,8 @@ public final class WristConstants {
   public final Current wristStatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
   public final Double wristReduction = 1.0; // TODO: Replace placeholder reduction
-
+  public final Angle wristMinMinAngle = Rotations.of(0.0); // TODO: Replace placeholder constraints
+  public final Angle wristMaxMaxAngle = Rotations.of(1.0);
   public static final class Sim {
     @JSONExclude
     public static final JSONSync<WristConstants.Sim> synced =

--- a/examples/WristMechanism.java
+++ b/examples/WristMechanism.java
@@ -1,0 +1,300 @@
+package frc.robot.subsystems.scoring;
+
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Volts;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
+
+import coppercore.parameter_tools.LoggedTunableNumber;
+import coppercore.wpilib_interface.UnitUtils;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import frc.robot.TestModeManager;
+import frc.robot.constants.JsonConstants;
+import org.littletonrobotics.junction.Logger;
+
+/**
+ * A Mechanism to manage the Wrist
+ *
+ * <ul>
+ *   <li>Uses closed-loop TorqueCurrentFOC control
+ */
+public class WristMechanism {
+  WristIO io;
+  WristInputsAutoLogged inputs = new WristInputsAutoLogged();
+  WristOutputsAutoLogged outputs = new WristOutputsAutoLogged();
+
+  MutAngle goalAngle = Rotations.mutable(0.0);
+  MutAngle clampedGoalAngle = Rotations.mutable(0.0);
+
+  MutAngle minAngle = JsonConstants.wristConstants.wristMinMinAngle.mutableCopy();
+  MutAngle maxAngle = JsonConstants.wristConstants.wristMaxMaxAngle.mutableCopy();
+
+  LoggedTunableNumber wristkP;
+  LoggedTunableNumber wristkI;
+  LoggedTunableNumber wristkD;
+
+  LoggedTunableNumber wristkS;
+  LoggedTunableNumber wristkV;
+  LoggedTunableNumber wristkA;
+  LoggedTunableNumber wristkG;
+
+  LoggedTunableNumber wristCruiseVelocity;
+  LoggedTunableNumber wristExpokV;
+  LoggedTunableNumber wristExpokA;
+
+  LoggedTunableNumber wristTuningSetpointRotations;
+  LoggedTunableNumber wristTuningOverrideVolts;
+
+  public WristMechanism(WristIO io) {
+    wristkP =
+        new LoggedTunableNumber("WristTunables/wristkP", JsonConstants.wristConstants.wristKP);
+    wristkI =
+        new LoggedTunableNumber("WristTunables/wristkI", JsonConstants.wristConstants.wristKI);
+    wristkD =
+        new LoggedTunableNumber("WristTunables/wristkD", JsonConstants.wristConstants.wristKD);
+
+    wristkS =
+        new LoggedTunableNumber("WristTunables/wristkS", JsonConstants.wristConstants.wristKS);
+    wristkV =
+        new LoggedTunableNumber("WristTunables/wristkV", JsonConstants.wristConstants.wristKV);
+    wristkA =
+        new LoggedTunableNumber("WristTunables/wristkA", JsonConstants.wristConstants.wristKA);
+    wristkG =
+        new LoggedTunableNumber("WristTunables/wristkG", JsonConstants.wristConstants.wristKG);
+
+    wristCruiseVelocity =
+        new LoggedTunableNumber(
+            "WristTunables/wristCruiseVelocity",
+            JsonConstants.wristConstants.wristMotionMagicCruiseVelocityRotationsPerSecond);
+    wristExpokV =
+        new LoggedTunableNumber(
+            "WristTunables/wristExpokV", JsonConstants.wristConstants.wristMotionMagicExpo_kV);
+    wristExpokA =
+        new LoggedTunableNumber(
+            "WristTunables/wristExpokA", JsonConstants.wristConstants.wristMotionMagicExpo_kA);
+
+    wristTuningSetpointRotations =
+        new LoggedTunableNumber("WristTunables/wristTuningSetpointRotations", 0.0);
+    wristTuningOverrideVolts =
+        new LoggedTunableNumber("WristTunables/wristTuningOverrideVolts", 0.0);
+
+    this.io = io;
+  }
+
+  /**
+   * Runs periodically when the robot is enabled
+   *
+   * <p>Does NOT run automatically! Must be called by the subsystem
+   */
+  public void periodic() {
+    sendGoalAngleToIO();
+
+    io.updateInputs(inputs);
+    io.applyOutputs(outputs);
+
+    Logger.processInputs("Wrist/inputs", inputs);
+    Logger.processInputs("Wrist/outputs", outputs);
+  }
+
+  public void setBrakeMode(boolean brake) {
+    io.setBrakeMode(brake);
+  }
+
+  /** This method must be called from the subsystem's test periodic! */
+  public void testPeriodic() {
+    switch (TestModeManager.getTestMode()) {
+      case WristClosedLoopTuning:
+        io.setOverrideMode(false);
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (pid) -> {
+              io.setPID(pid[0], pid[1], pid[2]);
+            },
+            wristkP,
+            wristkI,
+            wristkD);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (ff) -> {
+              io.setFF(ff[0], ff[1], ff[2], ff[3]);
+            },
+            wristkS,
+            wristkV,
+            wristkA,
+            wristkG);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (maxProfile) -> {
+              io.setMaxProfile(
+                  RadiansPerSecond.of(0.0),
+                  VoltsPerRadianPerSecondSquared.ofNative(maxProfile[0]),
+                  VoltsPerRadianPerSecond.ofNative(maxProfile[1]));
+            },
+            wristExpokA,
+            wristExpokV);
+
+      case SetpointTuning:
+        // Allow setpointing in WristClosedLoopTuning and SetpointTuning
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              setGoalAngle(Rotations.of(setpoint[0]));
+            },
+            wristTuningSetpointRotations);
+        break;
+      case WristVoltageTuning:
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              io.setOverrideVoltage(Volts.of(setpoint[0]));
+            },
+            wristTuningOverrideVolts);
+        io.setOverrideMode(true);
+        break;
+      default:
+        break;
+    }
+  }
+
+  public void sendGoalAngleToIO() {
+    updateClampedGoalAngle();
+  }
+
+  /**
+   * Based on the bounds previously set, clamp the last set goal angle to be between the bounds.
+   *
+   * <p>If the goal height is outside of the bounds and the bounds are expanded, this function will
+   * still behave as expected, as the mechanism remembers its unclamped goal height and will attempt
+   * to get there once it is allowed.
+   */
+  private void updateClampedGoalAngle() {
+    clampedGoalAngle.mut_replace(UnitUtils.clampMeasure(goalAngle, minAngle, maxAngle));
+
+    Logger.recordOutput("Wrist/clampedGoalAngle", clampedGoalAngle);
+  }
+
+  /**
+   * Set the goal angle the wrist will to control about.
+   *
+   * <p>This goal angle will be clamped by the allowed range of motion
+   *
+   * @param goalAngle The new goal angle
+   */
+  public void setGoalAngle(Angle goalAngle) {
+    this.goalAngle.mut_replace(goalAngle);
+
+    Logger.recordOutput("Wrist/goalAngle", goalAngle);
+  }
+  /**
+   * Sets the minimum and maximum allowed angles that the wrist may target.
+   *
+   * <p>When not in override mode, the goal angle of the wrist will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param minAngle The minimum angle, which will be clamped between wristMinMinAngle and
+   *     wristMaxMaxAngle before being applied
+   * @param maxAngle The maximum angle, which will be clamped between wristMinMinAngle and
+   *     wristMaxMaxAngle before being applied
+   */
+  public void setAllowedRangeOfMotion(Angle minAngle, Angle maxAngle) {
+    setMinAngle(minAngle);
+    setMaxAngle(maxAngle);
+  }
+
+  /**
+   * Sets the minimum allowed angle that the wrist may target.
+   *
+   * <p>When not in override mode, the goal angle of the wrist will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param minAngle The minimum angle, which will be clamped between wristMinMinAngle and
+   *     wristMaxMaxAngle before being applied
+   */
+  public void setMinAngle(Angle minAngle) {
+    this.minAngle.mut_replace(
+        UnitUtils.clampMeasure(
+            minAngle,
+            JsonConstants.wristConstants.wristMinMinAngle,
+            JsonConstants.wristConstants.wristMaxMaxAngle));
+
+    Logger.recordOutput("Wrist/minAngle", minAngle);
+  }
+
+  /**
+   * Sets the maximum allowed angle that the wrist may target.
+   *
+   * <p>When not in override mode, the goal angle of the wrist will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param maxAngle The maximum angle, which will be clamped between wristMinMinAngle and
+   *     wristMaxMaxAngle before being applied
+   */
+  public void setMaxAngle(Angle maxAngle) {
+    this.maxAngle.mut_replace(
+        UnitUtils.clampMeasure(
+            maxAngle,
+            JsonConstants.wristConstants.wristMaxMaxAngle,
+            JsonConstants.wristConstants.wristMaxMaxAngle));
+
+    Logger.recordOutput("Wrist/maxAngle", maxAngle);
+  }
+
+  /**
+   * Get the current angle of the wrist
+   *
+   * @return
+   */
+  public Angle getWristAngle() {
+    return inputs.wristEncoderPos;
+  }
+
+  /**
+   * Get the current velocity of the wrist
+   *
+   * @return The current velocity of the wrist, according to the wristEncoder
+   */
+  public AngularVelocity getWristVelocity() {
+    return inputs.wristEncoderVel;
+  }
+
+  /**
+   * Check whether or not the wristEncoder is currently connected.
+   *
+   * <p>"Connected" means that last time the position and velocity status signals were refreshed, the status code
+   * was OK
+   *
+   * @return True if connected, false if disconnected
+   */
+  public boolean isWristEncoderConnected() {
+    return inputs.wristEncoderConnected;
+  }
+
+  /**
+   * Get a reference to the wrist's IO. This should be used to update PID, motion profile, and feed
+   * forward gains, and to set brake mode/disable motors. This method exists to avoid the need to
+   * duplicate all of these functions between the mechanism and the IO.
+   *
+   * @return the wrist mechanism's IO
+   */
+  public WristIO getIO() {
+    return io;
+  }
+
+  /** Set whether or not the motor on the wrist should be disabled */
+  public void setMotorsDisabled(boolean disabled) {
+    io.setMotorsDisabled(disabled);
+  }
+
+  /** Get the current unclamped goal angle of the wrist */
+  public Angle getWristGoalAngle() {
+    return goalAngle;
+  }
+}

--- a/src/robotvibecoder_aidnem/subcommands/generate.py
+++ b/src/robotvibecoder_aidnem/subcommands/generate.py
@@ -38,10 +38,11 @@ def generate(args: Namespace) -> None:
             "Mechanism kinds beside Arm are not implemented yet :("
         )
 
-    file_templates: dict[str, str] = {
-        "{name}IO.java.j2": "{name}IO.java",
-        "{name}IOTalonFX.java.j2": "{name}IOTalonFX.java",
-        "{name}Constants.java.j2": "{name}Constants.java",
+    template_to_output_map: dict[str, str] = {
+        "Mechanism.java.j2": "{name}Mechanism.java",
+        "MechanismIO.java.j2": "{name}IO.java",
+        "MechanismIOTalonFX.java.j2": "{name}IOTalonFX.java",
+        "MechanismConstants.java.j2": "{name}Constants.java",
         config.kind + "Sim.java.j2": "{name}IOSim.java",
     }
 
@@ -49,9 +50,10 @@ def generate(args: Namespace) -> None:
         print(
             f"{constants.Colors.fg_red}{constants.Colors.bold}WARNING{constants.Colors.reset}: This will create/overwrite files at the following paths:"
         )
-        for file_template in file_templates:
+        for file_template in template_to_output_map:
             output_path = os.path.join(
-                args.folder, file_templates[file_template].format(name=config.name)
+                args.folder,
+                template_to_output_map[file_template].format(name=config.name),
             )
             print(f"  {output_path}")
         try:
@@ -61,9 +63,9 @@ def generate(args: Namespace) -> None:
             sys.exit(0)
 
     print("Templating files:")
-    for file_template in file_templates:
+    for file_template in template_to_output_map:
         output_path = os.path.join(
-            args.folder, file_templates[file_template].format(name=config.name)
+            args.folder, template_to_output_map[file_template].format(name=config.name)
         )
 
         if os.path.exists(output_path) and args.stdin:
@@ -74,7 +76,7 @@ def generate(args: Namespace) -> None:
             sys.exit(1)
 
         print(f"{constants.Colors.fg_cyan}➜{constants.Colors.reset} {output_path}")
-        template_path = file_template.format(name="Mechanism")
+        template_path = file_template
         template = env.get_template(template_path)
 
         output: str = template.render(config.__dict__)

--- a/src/robotvibecoder_aidnem/subcommands/generate.py
+++ b/src/robotvibecoder_aidnem/subcommands/generate.py
@@ -27,7 +27,7 @@ def generate(args: Namespace) -> None:
             sys.exit(1)
         config_path = os.path.join(args.folder, args.config)
         print(f"[{constants.Colors.title_str}] Reading config file at {config_path}")
-        config: MechanismConfig = load_json_config(config_path)
+        config = load_json_config(config_path)
 
     validate_config(config)
 

--- a/src/robotvibecoder_aidnem/subcommands/new.py
+++ b/src/robotvibecoder_aidnem/subcommands/new.py
@@ -28,7 +28,7 @@ def new_config_interactive() -> MechanismConfig:
         kind = input("> ")
         if kind not in MechanismKind:
             print("Please input either Elevator, Arm, or Flywheel.")
-    kind_enum: MechanismKind = kind
+    kind_enum: MechanismKind = MechanismKind[kind]
 
     print("CAN Bus: whatever the name of the mechanism's bus is (e.g. `canivore`)")
     canbus: str = input("> ")

--- a/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
+++ b/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
@@ -8,15 +8,16 @@ import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
 
 import coppercore.parameter_tools.LoggedTunableNumber;
 import coppercore.wpilib_interface.UnitUtils;
-import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.MutAngle;
-import frc.robot.TestModeManager;
-import frc.robot.constants.JsonConstants;
+{%-if kind != "Flywheel" %}
+import edu.wpi.first.units.measure.{{ kind|pos_dimension }};
+import edu.wpi.first.units.measure.Mut{{ kind|pos_dimension }};
+{%- endif %}
+import edu.wpi.first.units.measure.{{ kind|vel_dimension }};
+import frc.robot.{{ package }}.{{ name }}IO.{{ name }}OutputMode;
 import org.littletonrobotics.junction.Logger;
 
 /**
- * A Mechanism to keep track of the {{ name }}
+ * A Mechanism to manage the {{ name }}
  *
  * <ul>
  *   <li>Uses closed-loop TorqueCurrentFOC control
@@ -26,11 +27,13 @@ public class {{ name }}Mechanism {
   {{ name }}InputsAutoLogged inputs = new {{ name }}InputsAutoLogged();
   {{ name }}OutputsAutoLogged outputs = new {{ name }}OutputsAutoLogged();
 
-  MutAngle goalAngle = Rotations.mutable(0.0);
-  MutAngle clampedGoalAngle = Rotations.mutable(0.0);
+  Mut{{ kind|pos_dimension }} goal{{ kind|goal }} = Rotations.mutable(0.0);
+{%- if kind != "Flywheel" %}
+  Mut{{ kind|pos_dimension }} clampedGoal{{ kind|goal }} = Rotations.mutable(0.0);
+{%- endif %}
 
-  MutAngle minAngle = JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MinMinAngle.mutableCopy();
-  MutAngle maxAngle = JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle.mutableCopy();
+  Mut{{ kind|pos_dimension }} min{{ kind|pos_dimension }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMin{{ kind|pos_dimension }}.mutableCopy();
+  Mut{{ kind|pos_dimension }} max{{ kind|pos_dimension }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|pos_dimension }}.mutableCopy();
 
   LoggedTunableNumber {{ name|lowerfirst }}kP;
   LoggedTunableNumber {{ name|lowerfirst }}kI;
@@ -50,31 +53,31 @@ public class {{ name }}Mechanism {
 
   public {{ name }}Mechanism({{ name }}IO io) {
     {{ name|lowerfirst }}kP =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kP", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KP);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kP", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KP);
     {{ name|lowerfirst }}kI =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kI", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KI);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kI", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KI);
     {{ name|lowerfirst }}kD =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kD", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KD);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kD", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KD);
 
     {{ name|lowerfirst }}kS =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kS", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KS);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kS", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KS);
     {{ name|lowerfirst }}kV =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kV", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KV);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kV", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KV);
     {{ name|lowerfirst }}kA =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kA", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KA);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kA", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KA);
     {{ name|lowerfirst }}kG =
-        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kG", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KG);
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kG", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KG);
 
     {{ name|lowerfirst }}CruiseVelocity =
         new LoggedTunableNumber(
             "{{ name }}Tunables/{{ name|lowerfirst }}CruiseVelocity",
-            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicCruiseVelocityRotationsPerSecond);
+            {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}AngularCruiseVelocityRotationsPerSecond);
     {{ name|lowerfirst }}ExpokV =
         new LoggedTunableNumber(
-            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokV", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicExpo_kV);
+            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokV", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MotionMagicExpo_kV);
     {{ name|lowerfirst }}ExpokA =
         new LoggedTunableNumber(
-            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokA", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicExpo_kA);
+            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokA", {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MotionMagicExpo_kA);
 
     {{ name|lowerfirst }}TuningSetpointRotations =
         new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}TuningSetpointRotations", 0.0);
@@ -90,7 +93,7 @@ public class {{ name }}Mechanism {
    * <p>Does NOT run automatically! Must be called by the subsystem
    */
   public void periodic() {
-    sendGoalAngleToIO();
+    sendGoal{{ kind|goal }}ToIO();
 
     io.updateInputs(inputs);
     io.applyOutputs(outputs);
@@ -105,9 +108,10 @@ public class {{ name }}Mechanism {
 
   /** This method must be called from the subsystem's test periodic! */
   public void testPeriodic() {
-    switch (TestModeManager.getTestMode()) {
-      case {{ name }}ClosedLoopTuning:
-        io.setOverrideMode(false);
+    if (false) { // TODO: Replace placeholder test if {{ name }}Tuning mode is active
+      // switch (TestModeManager.getTestMode()) {
+      // case {{ name }}ClosedLoopTuning:
+        io.setOutputMode({{ name }}OutputMode.ClosedLoop);
         LoggedTunableNumber.ifChanged(
             hashCode(),
             (pid) -> {
@@ -138,138 +142,154 @@ public class {{ name }}Mechanism {
             {{ name|lowerfirst }}ExpokA,
             {{ name|lowerfirst }}ExpokV);
 
-      case SetpointTuning:
-        // Allow setpointing in {{ name }}ClosedLoopTuning and SetpointTuning
         LoggedTunableNumber.ifChanged(
             hashCode(),
             (setpoint) -> {
-              setGoalAngle(Rotations.of(setpoint[0]));
+              setGoal{{ kind|pos_dimension }}(Rotations.of(setpoint[0]));
             },
             {{ name|lowerfirst }}TuningSetpointRotations);
-        break;
-      case {{ name }}VoltageTuning:
-        LoggedTunableNumber.ifChanged(
+      /*  case {{ name }}VoltageTuning:
+          LoggedTunableNumber.ifChanged(
             hashCode(),
             (setpoint) -> {
               io.setOverrideVoltage(Volts.of(setpoint[0]));
             },
             {{ name|lowerfirst }}TuningOverrideVolts);
-        io.setOverrideMode(true);
-        break;
-      default:
-        break;
+          io.setOverrideMode(true);
+          break;
+        }
+        */
     }
   }
 
-  public void sendGoalAngleToIO() {
-    updateClampedGoalAngle();
+  public void sendGoal{{ kind|goal }}ToIO() {
+{%- if kind != "Flywheel"%}
+    updateClampedGoal{{ kind|goal }}();
 
-    io.set{{ name }}GoalPos(clampedGoalAngle);
+{%- if kind == "Arm" %}
+    io.set{{ encoder|upperfirst }}GoalPos(clampedGoal{{ kind|goal }});
+{%- elif kind == "Elevator" %}
+    // Convert goal height to encoder rotations
+    Angle {{ encoder }}GoalAngle = {{ name|lowerfirst }}HeightTo{{ encoder|upperfirst }}Angle(clampedGoal{{ kind|goal }});
+
+    io.set {{ encoder|upperfirst }}GoalPos({{ encoder }}GoalAngle);
+{%- endif %}
+{%- else %}
+    io.set{{ encoder|upperfirst }}GoalSpeed(goal{{ kind|goal }});
+{%- endif%}
   }
+{%- if kind != "Flywheel "%}
 
   /**
-   * Based on the bounds previously set, clamp the last set goal height to be between the bounds.
+   * Based on the bounds previously set, clamp the last set goal {{ kind|goal|lowerfirst }} to be between the bounds.
    *
    * <p>If the goal height is outside of the bounds and the bounds are expanded, this function will
    * still behave as expected, as the mechanism remembers its unclamped goal height and will attempt
    * to get there once it is allowed.
    */
-  private void updateClampedGoalAngle() {
-    clampedGoalAngle.mut_replace(UnitUtils.clampMeasure(goalAngle, minAngle, maxAngle));
+  private void updateClampedGoal{{ kind|goal }}() {
+    clampedGoal{{ kind|goal }}.mut_replace(UnitUtils.clampMeasure(goal{{ kind|pos_dimension }}, min{{ kind|pos_dimension }}, max{{ kind|pos_dimension }}));
 
-    Logger.recordOutput("{{ name }}/clampedGoalAngle", clampedGoalAngle);
+    Logger.recordOutput("{{ name }}/clampedGoal{{ kind|goal }}", clampedGoal{{ kind|goal }});
   }
+{%- endif %}
 
   /**
    * Set the goal angle the {{ name|lowerfirst }} will to control about.
    *
    * <p>This goal angle will be clamped by the allowed range of motion
    *
-   * @param goalAngle The new goal angle
+   * @param goal{{ kind|pos_dimension }} The new goal angle
    */
-  public void setGoalAngle(Angle goalAngle) {
-    this.goalAngle.mut_replace(goalAngle);
+  public void setGoal{{ kind|pos_dimension }}({{ kind|pos_dimension }} goal{{ kind|pos_dimension }}) {
+    this.goal{{ kind|pos_dimension }}.mut_replace(goal{{ kind|pos_dimension }});
 
-    Logger.recordOutput("{{ name }}/goalAngle", goalAngle);
+    Logger.recordOutput("{{ name }}/goal{{ kind|pos_dimension }}", goal{{ kind|pos_dimension }});
   }
 
+{%- if kind != "Flywheel" %}
   /**
-   * Sets the minimum and maximum allowed angles that the {{ name|lowerfirst }} may target.
+   * Sets the minimum and maximum allowed {{ kind|goal|lowerfirst }}s that the {{ name|lowerfirst }} may target.
    *
-   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
-   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * <p>When not in override mode, the goal {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }} will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal {{ kind|goal|lowerfirst }} is
    * clamped to be within the new bounds.
    *
-   * @param minAngle The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
-   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
-   * @param maxAngle The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
-   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   * @param min{{ kind|goal }} The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMin{{ kind|pos_dimension }} and
+   *     {{ name|lowerfirst }}MaxMax{{ kind|pos_dimension }} before being applied
+   * @param max{{ kind|goal }} The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMin{{ kind|pos_dimension }} and
+   *     {{ name|lowerfirst }}MaxMax{{ kind|pos_dimension }} before being applied
    */
-  public void setAllowedRangeOfMotion(Angle minAngle, Angle maxAngle) {
-    setMinAngle(minAngle);
-    setMaxAngle(maxAngle);
+  public void setAllowedRangeOfMotion({{ kind|pos_dimension }} min{{ kind|goal }}, {{ kind|pos_dimension }} max{{ kind|goal }}) {
+    setMin{{ kind|goal }}(min{{ kind|pos_dimension }});
+    setMax{{ kind|goal }}(max{{ kind|pos_dimension }});
   }
 
   /**
    * Sets the minimum allowed angle that the {{ name|lowerfirst }} may target.
    *
-   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
-   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * <p>When not in override mode, the goal {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }} will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal {{ kind|goal|lowerfirst }} is
    * clamped to be within the new bounds.
    *
-   * @param minAngle The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
-   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   * @param min{{ kind|goal }} The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMin{{ kind|goal }} and
+   *     {{ name|lowerfirst }}MaxMax{{ kind|goal }} before being applied
    */
-  public void setMinAngle(Angle minAngle) {
-    this.minAngle.mut_replace(
+  public void setMin{{ kind|goal }}({{ kind|pos_dimension }} min{{ kind|goal }}) {
+    this.min{{ kind|pos_dimension }}.mut_replace(
         UnitUtils.clampMeasure(
-            minAngle,
-            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MinMinAngle,
-            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle));
+            min{{ kind|pos_dimension }},
+            {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMin{{ kind|goal }},
+            {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|goal }}));
 
-    Logger.recordOutput("{{ name }}/minAngle", minAngle);
+    Logger.recordOutput("{{ name }}/min{{ kind|goal }}", min{{ kind|goal }});
   }
 
   /**
    * Sets the maximum allowed angle that the {{ name|lowerfirst }} may target.
    *
-   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
+   * <p>When not in override mode, the goal {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }} will be clamped to be between these
    * values before it is sent to the IO. When these clamps change, the original goal angle is
    * clamped to be within the new bounds.
    *
-   * @param maxAngle The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
-   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   * @param max{{ kind|goal }} The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMin{{ kind|goal }} and
+   *     {{ name|lowerfirst }}MaxMax{{ kind|goal }} before being applied
    */
-  public void setMaxAngle(Angle maxAngle) {
-    this.maxAngle.mut_replace(
+  public void setMax{{ kind|goal }}({{ kind|pos_dimension }} max{{ kind|goal }}) {
+    this.max{{ kind|goal }}.mut_replace(
         UnitUtils.clampMeasure(
-            maxAngle,
-            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle,
-            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle));
+            max{{ kind|goal }},
+            {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|goal }},
+            {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|goal }}));
 
-    Logger.recordOutput("{{ name }}/maxAngle", maxAngle);
+    Logger.recordOutput("{{ name }}/max{{ kind|goal }}", max{{ kind|goal }});
   }
 
   /**
-   * Get the current angle of the {{ name|lowerfirst }}
+   * Get the current {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }}
    *
    * @return
    */
-  public Angle get{{ name }}Angle() {
-    return inputs.{{ name|lowerfirst }}Position;
+  public {{ kind|pos_dimension }} get{{ name }}{{ kind|goal }}() {
+{%- if kind == "Arm" %}
+    return inputs.{{ encoder }}Pos;
+{%- elif kind == "Elevator "%}
+    return {{ encoder }}AngleTo{{ name }}Height(inputs.{{ encoder }}Pos);
+{%- endif%}
   }
+{%- endif %}
 
   /**
-   * Get the current angular velocity of the {{ name|lowerfirst }}
+   * Get the current velocity of the {{ name|lowerfirst }}
    *
    * @return The current velocity of the {{ name|lowerfirst }}, according to the {{ encoder }}
    */
-  public AngularVelocity get{{ name }}Velocity() {
-    return inputs.{{ name|lowerfirst }}Velocity;
+  public {{ kind|vel_dimension }} get{{ name }}Velocity() {
+    return inputs.{{ encoder }}Vel;
   }
 
   /**
-   * Check whether or not the {{ encoder}} is currently connected.
+   * Check whether or not the {{ encoder }} is currently connected.
    *
    * <p>"Connected" means that last time the position and velocity status signals were refreshed, the status code
    * was OK
@@ -277,7 +297,7 @@ public class {{ name }}Mechanism {
    * @return True if connected, false if disconnected
    */
   public boolean is{{ encoder|upperfirst }}Connected() {
-    return inputs.is{{ encoder|upperfirst }}Connected;
+    return inputs.{{ encoder }}Connected;
   }
 
   /**
@@ -296,8 +316,30 @@ public class {{ name }}Mechanism {
     io.setMotorsDisabled(disabled);
   }
 
-  /** Get the current unclamped angle of the {{ name|lowerfirst }} */
-  public Angle get{{ name }}GoalAngle() {
-    return goalAngle;
+  /** Get the current{%if kind != "Flywheel"%} unclamped{% endif %} goal {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }} */
+  public {{ kind|goal_dimension }} get{{ name }}Goal{{ kind|goal }}() {
+    return goal{{ kind|goal }};
   }
+{%- if kind == "Elevator" %}
+
+  /**
+   * Convert an angle of the {{ encoder }} into {{ name }} height
+   *
+   * @param {{ encoder }}Angle The encoder angle to convert
+   * @return How much the {{ name }} would move if the {{ encoder }} were rotated by {{ encoder }}Angle
+   */
+  public Distance {{ encoder }}AngleTo{{ name }}Height(Angle {{ encoder }}Angle) {
+    return Meters.of({{ encoder }}Angle.in(Rotations) * {{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
+  }
+
+  /**
+   * Convert {{ name }} height into {{ encoder }} angle
+   *
+   * @param {{ name }}Height The distance of the {{ name }} to convert
+   * @return How much the {{ encoder }} would rotate if the {{ name }} were moved by {{ name }}Height
+   */
+   public Angle {{ name|lowerfirst }}HeightTo{{ encoder|upperfirst }}Angle(Distance {{ name|lowerfirst }}Height) {
+    return Rotations.of({{ name|lowerfirst }}Height.in(Meters) / {{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
+   }
+{%- endif%}
 }

--- a/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
+++ b/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
@@ -163,7 +163,7 @@ public class {{ name }}Mechanism {
   }
 
   public void sendGoal{{ kind|goal }}ToIO() {
-{%- if kind != "Flywheel"%}
+{%- if kind != "Flywheel" %}
     updateClampedGoal{{ kind|goal }}();
 
 {%- if kind == "Arm" %}
@@ -178,7 +178,7 @@ public class {{ name }}Mechanism {
     io.set{{ encoder|upperfirst }}GoalSpeed(goal{{ kind|goal }});
 {%- endif%}
   }
-{%- if kind != "Flywheel "%}
+{%- if kind != "Flywheel" %}
 
   /**
    * Based on the bounds previously set, clamp the last set goal {{ kind|goal|lowerfirst }} to be between the bounds.

--- a/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
+++ b/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
@@ -1,0 +1,303 @@
+package frc.robot.{{ package }};
+
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Volts;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
+
+import coppercore.parameter_tools.LoggedTunableNumber;
+import coppercore.wpilib_interface.UnitUtils;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.MutAngle;
+import frc.robot.TestModeManager;
+import frc.robot.constants.JsonConstants;
+import org.littletonrobotics.junction.Logger;
+
+/**
+ * A Mechanism to keep track of the {{ name }}
+ *
+ * <ul>
+ *   <li>Uses closed-loop TorqueCurrentFOC control
+ */
+public class {{ name }}Mechanism {
+  {{ name }}IO io;
+  {{ name }}InputsAutoLogged inputs = new {{ name }}InputsAutoLogged();
+  {{ name }}OutputsAutoLogged outputs = new {{ name }}OutputsAutoLogged();
+
+  MutAngle goalAngle = Rotations.mutable(0.0);
+  MutAngle clampedGoalAngle = Rotations.mutable(0.0);
+
+  MutAngle minAngle = JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MinMinAngle.mutableCopy();
+  MutAngle maxAngle = JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle.mutableCopy();
+
+  LoggedTunableNumber {{ name|lowerfirst }}kP;
+  LoggedTunableNumber {{ name|lowerfirst }}kI;
+  LoggedTunableNumber {{ name|lowerfirst }}kD;
+
+  LoggedTunableNumber {{ name|lowerfirst }}kS;
+  LoggedTunableNumber {{ name|lowerfirst }}kV;
+  LoggedTunableNumber {{ name|lowerfirst }}kA;
+  LoggedTunableNumber {{ name|lowerfirst }}kG;
+
+  LoggedTunableNumber {{ name|lowerfirst }}CruiseVelocity;
+  LoggedTunableNumber {{ name|lowerfirst }}ExpokV;
+  LoggedTunableNumber {{ name|lowerfirst }}ExpokA;
+
+  LoggedTunableNumber {{ name|lowerfirst }}TuningSetpointRotations;
+  LoggedTunableNumber {{ name|lowerfirst }}TuningOverrideVolts;
+
+  public {{ name }}Mechanism({{ name }}IO io) {
+    {{ name|lowerfirst }}kP =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kP", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KP);
+    {{ name|lowerfirst }}kI =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kI", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KI);
+    {{ name|lowerfirst }}kD =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kD", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KD);
+
+    {{ name|lowerfirst }}kS =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kS", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KS);
+    {{ name|lowerfirst }}kV =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kV", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KV);
+    {{ name|lowerfirst }}kA =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kA", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KA);
+    {{ name|lowerfirst }}kG =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}kG", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}KG);
+
+    {{ name|lowerfirst }}CruiseVelocity =
+        new LoggedTunableNumber(
+            "{{ name }}Tunables/{{ name|lowerfirst }}CruiseVelocity",
+            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicCruiseVelocityRotationsPerSecond);
+    {{ name|lowerfirst }}ExpokV =
+        new LoggedTunableNumber(
+            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokV", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicExpo_kV);
+    {{ name|lowerfirst }}ExpokA =
+        new LoggedTunableNumber(
+            "{{ name }}Tunables/{{ name|lowerfirst }}ExpokA", JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MotionMagicExpo_kA);
+
+    {{ name|lowerfirst }}TuningSetpointRotations =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}TuningSetpointRotations", 0.0);
+    {{ name|lowerfirst }}TuningOverrideVolts =
+        new LoggedTunableNumber("{{ name }}Tunables/{{ name|lowerfirst }}TuningOverrideVolts", 0.0);
+
+    this.io = io;
+  }
+
+  /**
+   * Runs periodically when the robot is enabled
+   *
+   * <p>Does NOT run automatically! Must be called by the subsystem
+   */
+  public void periodic() {
+    sendGoalAngleToIO();
+
+    io.updateInputs(inputs);
+    io.applyOutputs(outputs);
+
+    Logger.processInputs("{{ name }}/inputs", inputs);
+    Logger.processInputs("{{ name }}/outputs", outputs);
+  }
+
+  public void setBrakeMode(boolean brake) {
+    io.setBrakeMode(brake);
+  }
+
+  /** This method must be called from the subsystem's test periodic! */
+  public void testPeriodic() {
+    switch (TestModeManager.getTestMode()) {
+      case {{ name }}ClosedLoopTuning:
+        io.setOverrideMode(false);
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (pid) -> {
+              io.setPID(pid[0], pid[1], pid[2]);
+            },
+            {{ name|lowerfirst }}kP,
+            {{ name|lowerfirst }}kI,
+            {{ name|lowerfirst }}kD);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (ff) -> {
+              io.setFF(ff[0], ff[1], ff[2], ff[3]);
+            },
+            {{ name|lowerfirst }}kS,
+            {{ name|lowerfirst }}kV,
+            {{ name|lowerfirst }}kA,
+            {{ name|lowerfirst }}kG);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (maxProfile) -> {
+              io.setMaxProfile(
+                  RadiansPerSecond.of(0.0),
+                  VoltsPerRadianPerSecondSquared.ofNative(maxProfile[0]),
+                  VoltsPerRadianPerSecond.ofNative(maxProfile[1]));
+            },
+            {{ name|lowerfirst }}ExpokA,
+            {{ name|lowerfirst }}ExpokV);
+
+      case SetpointTuning:
+        // Allow setpointing in {{ name }}ClosedLoopTuning and SetpointTuning
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              setGoalAngle(Rotations.of(setpoint[0]));
+            },
+            {{ name|lowerfirst }}TuningSetpointRotations);
+        break;
+      case {{ name }}VoltageTuning:
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              io.setOverrideVoltage(Volts.of(setpoint[0]));
+            },
+            {{ name|lowerfirst }}TuningOverrideVolts);
+        io.setOverrideMode(true);
+        break;
+      default:
+        break;
+    }
+  }
+
+  public void sendGoalAngleToIO() {
+    updateClampedGoalAngle();
+
+    io.set{{ name }}GoalPos(clampedGoalAngle);
+  }
+
+  /**
+   * Based on the bounds previously set, clamp the last set goal height to be between the bounds.
+   *
+   * <p>If the goal height is outside of the bounds and the bounds are expanded, this function will
+   * still behave as expected, as the mechanism remembers its unclamped goal height and will attempt
+   * to get there once it is allowed.
+   */
+  private void updateClampedGoalAngle() {
+    clampedGoalAngle.mut_replace(UnitUtils.clampMeasure(goalAngle, minAngle, maxAngle));
+
+    Logger.recordOutput("{{ name }}/clampedGoalAngle", clampedGoalAngle);
+  }
+
+  /**
+   * Set the goal angle the {{ name|lowerfirst }} will to control about.
+   *
+   * <p>This goal angle will be clamped by the allowed range of motion
+   *
+   * @param goalAngle The new goal angle
+   */
+  public void setGoalAngle(Angle goalAngle) {
+    this.goalAngle.mut_replace(goalAngle);
+
+    Logger.recordOutput("{{ name }}/goalAngle", goalAngle);
+  }
+
+  /**
+   * Sets the minimum and maximum allowed angles that the {{ name|lowerfirst }} may target.
+   *
+   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param minAngle The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
+   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   * @param maxAngle The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
+   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   */
+  public void setAllowedRangeOfMotion(Angle minAngle, Angle maxAngle) {
+    setMinAngle(minAngle);
+    setMaxAngle(maxAngle);
+  }
+
+  /**
+   * Sets the minimum allowed angle that the {{ name|lowerfirst }} may target.
+   *
+   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param minAngle The minimum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
+   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   */
+  public void setMinAngle(Angle minAngle) {
+    this.minAngle.mut_replace(
+        UnitUtils.clampMeasure(
+            minAngle,
+            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MinMinAngle,
+            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle));
+
+    Logger.recordOutput("{{ name }}/minAngle", minAngle);
+  }
+
+  /**
+   * Sets the maximum allowed angle that the {{ name|lowerfirst }} may target.
+   *
+   * <p>When not in override mode, the goal angle of the {{ name|lowerfirst }} will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param maxAngle The maximum angle, which will be clamped between {{ name|lowerfirst }}MinMinAngle and
+   *     {{ name|lowerfirst }}MaxMaxAngle before being applied
+   */
+  public void setMaxAngle(Angle maxAngle) {
+    this.maxAngle.mut_replace(
+        UnitUtils.clampMeasure(
+            maxAngle,
+            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle,
+            JsonConstants.{{ name|lowerfirst }}Constants.{{ name|lowerfirst }}MaxMaxAngle));
+
+    Logger.recordOutput("{{ name }}/maxAngle", maxAngle);
+  }
+
+  /**
+   * Get the current angle of the {{ name|lowerfirst }}
+   *
+   * @return
+   */
+  public Angle get{{ name }}Angle() {
+    return inputs.{{ name|lowerfirst }}Position;
+  }
+
+  /**
+   * Get the current angular velocity of the {{ name|lowerfirst }}
+   *
+   * @return The current velocity of the {{ name|lowerfirst }}, according to the {{ encoder }}
+   */
+  public AngularVelocity get{{ name }}Velocity() {
+    return inputs.{{ name|lowerfirst }}Velocity;
+  }
+
+  /**
+   * Check whether or not the {{ encoder}} is currently connected.
+   *
+   * <p>"Connected" means that last time the position and velocity status signals were refreshed, the status code
+   * was OK
+   *
+   * @return True if connected, false if disconnected
+   */
+  public boolean is{{ encoder|upperfirst }}Connected() {
+    return inputs.is{{ encoder|upperfirst }}Connected;
+  }
+
+  /**
+   * Get a reference to the {{ name|lowerfirst }}'s IO. This should be used to update PID, motion profile, and feed
+   * forward gains, and to set brake mode/disable motors. This method exists to avoid the need to
+   * duplicate all of these functions between the mechanism and the IO.
+   *
+   * @return the {{ name|lowerfirst }} mechanism's IO
+   */
+  public {{ name }}IO getIO() {
+    return io;
+  }
+
+  /** Set whether or not the motor on the {{ name|lowerfirst }} should be disabled */
+  public void setMotorsDisabled(boolean disabled) {
+    io.setMotorsDisabled(disabled);
+  }
+
+  /** Get the current unclamped angle of the {{ name|lowerfirst }} */
+  public Angle get{{ name }}GoalAngle() {
+    return goalAngle;
+  }
+}

--- a/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
@@ -4,6 +4,9 @@ import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Radians;
+{%- if kind != "Flywheel" and kind|pos_unit != "Meters" %}
+import static edu.wpi.first.units.Units.{{ kind|pos_unit }};
+{%- endif %}
 
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import coppercore.parameter_tools.json.JSONExclude;
@@ -57,14 +60,14 @@ public final class {{ name }}Constants {
   @JSONExclude
   public final double rotorTo{{ encoder|upperfirst }}Ratio = 1.0; // TODO: Replace placeholder value
 
-  public final Double {{ name|lowerfirst }}kP = 0.0;
-  public final Double {{ name|lowerfirst }}kI = 0.0;
-  public final Double {{ name|lowerfirst }}kD = 0.0;
+  public final Double {{ name|lowerfirst }}KP = 0.0;
+  public final Double {{ name|lowerfirst }}KI = 0.0;
+  public final Double {{ name|lowerfirst }}KD = 0.0;
 
-  public final Double {{ name|lowerfirst }}kS = 0.0;
-  public final Double {{ name|lowerfirst }}kV = 0.0;
-  public final Double {{ name|lowerfirst }}kA = 0.0;
-  public final Double {{ name|lowerfirst }}kG = 0.0;
+  public final Double {{ name|lowerfirst }}KS = 0.0;
+  public final Double {{ name|lowerfirst }}KV = 0.0;
+  public final Double {{ name|lowerfirst }}KA = 0.0;
+  public final Double {{ name|lowerfirst }}KG = 0.0;
 
   /** This is a Double until coppercore JSONSync supports RotationsPerSecond */
   public final Double {{ name|lowerfirst }}AngularCruiseVelocityRotationsPerSecond = 1.0;
@@ -76,17 +79,22 @@ public final class {{ name }}Constants {
    * kV results in the maximum velocity of the system. Therefore, a higher profile kV results in a
    * lower profile velocity.
   */
-  public final Double {{ name|lowerfirst }}Expo_kV_raw = 0.0;
+  public final Double {{ name|lowerfirst }}MotionMagicExpo_kV = 0.0;
 
   /*
    * The Motion Magic Expo kA, measured in Volts per Radian per Second Squared, but represented as a double so it can be synced by JSONSync
   */
-  public final Double {{ name|lowerfirst }}Expo_kA_raw = 0.0;
+  public final Double {{ name|lowerfirst }}MotionMagicExpo_kA = 0.0;
 
   public final Current {{ name|lowerfirst }}StatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
   public final Double {{ name|lowerfirst }}Reduction = 1.0; // TODO: Replace placeholder reduction
 
+{%- if kind != "Flywheel" %}
+  public final {{ kind|pos_dimension }} {{ name|lowerfirst }}MinMin{{ kind|goal }} = {{ kind|pos_unit }}.of(0.0); // TODO: Replace placeholder constraints
+  public final {{ kind|pos_dimension }} {{ name|lowerfirst }}MaxMax{{ kind|goal }} = {{ kind|pos_unit }}.of(1.0);
+
+{%- endif %}
   public static final class Sim {
     @JSONExclude
     public static final JSONSync<{{ name }}Constants.Sim> synced =

--- a/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
@@ -124,21 +124,21 @@ public class {{ name }}IOTalonFX implements {{ name }}IO {
             .withSlot0(
                 new Slot0Configs()
                     .withGravityType(GravityTypeValue.{% if kind == "Arm" %}Arm_Cosine{% else %}Elevator_Static{% endif %})
-                    .withKS({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kS)
-                    .withKV({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kV)
-                    .withKA({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kA)
-                    .withKG({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kG)
-                    .withKP({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kP)
-                    .withKI({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kI)
-                    .withKD({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}kD))
+                    .withKS({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KS)
+                    .withKV({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KV)
+                    .withKA({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KA)
+                    .withKG({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KG)
+                    .withKP({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KP)
+                    .withKI({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KI)
+                    .withKD({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}KD))
             .withMotionMagic(
                 new MotionMagicConfigs()
                     .withMotionMagicCruiseVelocity(
                         {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}AngularCruiseVelocityRotationsPerSecond)
                     .withMotionMagicExpo_kA(
-                        {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Expo_kA_raw)
+                        {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MotionMagicExpo_kA)
                     .withMotionMagicExpo_kV(
-                        {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Expo_kV_raw));
+                        {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MotionMagicExpo_kV));
 
     // Apply talonFX config to motor{{ motors|plural }}
     {%- for motor in motors %}

--- a/src/robotvibecoder_aidnem/templating.py
+++ b/src/robotvibecoder_aidnem/templating.py
@@ -19,7 +19,7 @@ def upperfirst(word: str) -> str:
     return word[0].upper() + word[1:]
 
 
-canIdMap = {}
+canIdMap: dict[str, int] = {}
 nextId = 1
 
 
@@ -37,7 +37,7 @@ def hash_can_id(device: str) -> str:
         )
         nextId += 1
 
-    return canIdMap[device]
+    return str(canIdMap[device])
 
 
 def generate_env() -> Environment:

--- a/src/robotvibecoder_aidnem/templating.py
+++ b/src/robotvibecoder_aidnem/templating.py
@@ -40,6 +40,93 @@ def hash_can_id(device: str) -> str:
     return str(canIdMap[device])
 
 
+def pos_dimension(kind: str) -> str:
+    """
+    What dimension should be used for each kind of mechanism?
+    """
+    if kind == "Arm":
+        return "Angle"
+    elif kind == "Elevator":
+        return "Distance"
+    else:
+        print(
+            f"{constants.Colors.fg_red}Error:{constants.Colors.reset} Invalid kind {kind} passed to pos_dimension."
+        )
+        print(
+            "This is a robotvibecoder issue, NOT a user error. Please report this on github!"
+        )
+        raise ValueError(f"Invalid kind {kind} passed to pos_dimension")
+    # Flywheels won't have a position
+
+
+def vel_dimension(kind: str) -> str:
+    """
+    What dimension should be used for the velocity of each kind of mechanism?
+    """
+    if kind == "Elevator":
+        return "LinearVelocity"
+    else:
+        return "AngularVelocity"
+
+
+def pos_unit(kind: str) -> str:
+    """
+    What measure should be used for each kind of mechanism?
+    """
+    if kind == "Arm":
+        return "Rotations"
+    elif kind == "Elevator":
+        return "Meters"
+    else:
+        print(
+            f"{constants.Colors.fg_red}Error:{constants.Colors.reset} Invalid kind {kind} passed to pos_unit."
+        )
+        print(
+            "This is a robotvibecoder issue, NOT user error. Please report this on github!"
+        )
+        raise ValueError(f"Invalid kind {kind} passed to pos_unit")
+
+
+def vel_unit(kind: str) -> str:
+    """
+    What unit should be used for the velocity of each kind of mechanism?
+    """
+    if kind == "Elevator":
+        return "MetersPerSecond"
+    else:
+        return "RotationsPerSecond"
+
+
+def goal(kind: str) -> str:
+    """
+    What should the goal of each mechanism kind be described as?
+
+    E.g. arm has a goalAngle, flywheel has a goalSpeed, elevator has a goalHeight
+    """
+
+    if kind == "Arm":
+        return "Angle"
+    elif kind == "Elevator":
+        return "Height"
+    else:
+        return "Speed"
+
+
+def goal_dimension(kind: str) -> str:
+    """
+    What unit is the goal of each mechanism kind represented as?
+
+    E.g. arm uses Angle, elevator uses Distance, flywheel uses AngularVelocity
+    """
+
+    if kind == "Arm":
+        return "Angle"
+    elif kind == "Elevator":
+        return "Height"
+    else:
+        return "AngularVelocity"
+
+
 def generate_env() -> Environment:
     env = Environment(
         loader=PackageLoader("robotvibecoder_aidnem"), autoescape=select_autoescape()
@@ -50,5 +137,11 @@ def generate_env() -> Environment:
     env.filters["lowerfirst"] = lowerfirst
     env.filters["upperfirst"] = upperfirst
     env.filters["hash_can_id"] = hash_can_id
+    env.filters["pos_dimension"] = pos_dimension
+    env.filters["vel_dimension"] = vel_dimension
+    env.filters["pos_unit"] = pos_unit
+    env.filters["vel_unit"] = vel_unit
+    env.filters["goal"] = goal
+    env.filters["goal_dimension"] = goal_dimension
 
     return env


### PR DESCRIPTION
Adds Mechanism.java.j2 template to autogenerate a {name}Mechanism.java with a builtin tuning mode

This *should* work for all mechanism types but until IOs for elevator and Flywheel are implemented it can't really be tested.