### PR TITLE
Add elevator support

### DIFF
--- a/examples/ElevatorConstants.java
+++ b/examples/ElevatorConstants.java
@@ -1,38 +1,21 @@
 package frc.robot.subsystems.scoring; // NOTE: This should be changed if you keep your constants in a separate package from your code
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.Radians;
-import static edu.wpi.first.units.Units.RadiansPerSecond;
-import static edu.wpi.first.units.Units.Rotations;
-import static edu.wpi.first.units.Units.Seconds;
-import static edu.wpi.first.units.Units.Volts;
-import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
-import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
 
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import coppercore.parameter_tools.json.JSONExclude;
 import coppercore.parameter_tools.json.JSONSync;
 import coppercore.parameter_tools.json.JSONSyncConfigBuilder;
 import coppercore.parameter_tools.path_provider.EnvironmentHandler;
-import edu.wpi.first.units.AngleUnit;
-import edu.wpi.first.units.AngularAccelerationUnit;
-import edu.wpi.first.units.AngularVelocityUnit;
-import edu.wpi.first.units.DistanceUnit;
-import edu.wpi.first.units.PerUnit;
-import edu.wpi.first.units.VoltageUnit;
-import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
-import edu.wpi.first.units.measure.LinearVelocity;
-import edu.wpi.first.units.measure.Mass;
-import edu.wpi.first.units.measure.Per;
-import edu.wpi.first.units.measure.Time;
-import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.units.measure.MomentOfInertia;
 import edu.wpi.first.wpilibj.Filesystem;
+
 
 public final class ElevatorConstants {
   @JSONExclude
@@ -45,7 +28,6 @@ public final class ElevatorConstants {
 
   public final Integer leadMotorId = 1; // TODO: Replace placeholder CAN ID
   public final Integer followerMotorId = 2; // TODO: Replace placeholder CAN ID
-  public final Boolean invertFollowerElevatorMotor = true;
   public final Boolean invertFollowerMotorFollowerRequest = false;
 
   /**
@@ -53,6 +35,8 @@ public final class ElevatorConstants {
    * example, a value of 1 gives a range of [0.0, 1).
    */
   public final Double elevatorEncoderDiscontinuityPoint = 1.0;
+
+  public final Angle elevatorEncoderMagnetOffset = Radians.of(0.0);
 
   public final Integer elevatorEncoderID = 3; // TODO: Replace placeholder CAN ID
 
@@ -68,14 +52,14 @@ public final class ElevatorConstants {
   @JSONExclude
   public final double rotorToElevatorEncoderRatio = 1.0; // TODO: Replace placeholder value
 
-  public final Double elevatorkP = 0.0;
-  public final Double elevatorkI = 0.0;
-  public final Double elevatorkD = 0.0;
+  public final Double elevatorKP = 0.0;
+  public final Double elevatorKI = 0.0;
+  public final Double elevatorKD = 0.0;
 
-  public final Double elevatorkS = 0.0;
-  public final Double elevatorkV = 0.0;
-  public final Double elevatorkA = 0.0;
-  public final Double elevatorkG = 0.0;
+  public final Double elevatorKS = 0.0;
+  public final Double elevatorKV = 0.0;
+  public final Double elevatorKA = 0.0;
+  public final Double elevatorKG = 0.0;
 
   /** This is a Double until coppercore JSONSync supports RotationsPerSecond */
   public final Double elevatorAngularCruiseVelocityRotationsPerSecond = 1.0;
@@ -87,15 +71,18 @@ public final class ElevatorConstants {
    * kV results in the maximum velocity of the system. Therefore, a higher profile kV results in a
    * lower profile velocity.
   */
-  public final Double elevatorExpo_kV_raw = 0.0;
+  public final Double elevatorMotionMagicExpo_kV = 0.0;
 
   /*
    * The Motion Magic Expo kA, measured in Volts per Radian per Second Squared, but represented as a double so it can be synced by JSONSync
   */
-  public final Double elevatorExpo_kA_raw = 0.0;
+  public final Double elevatorMotionMagicExpo_kA = 0.0;
 
   public final Current elevatorStatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
+  public final Double elevatorReduction = 1.0; // TODO: Replace placeholder reduction
+  public final Distance elevatorMinMinHeight = Meters.of(0.0); // TODO: Replace placeholder constraints
+  public final Distance elevatorMaxMaxHeight = Meters.of(1.0);
   public static final class Sim {
     @JSONExclude
     public static final JSONSync<ElevatorConstants.Sim> synced =
@@ -112,5 +99,9 @@ public final class ElevatorConstants {
 
     /** Standard deviation passed to sim for the velocity measurement */
     public final Double velocityStdDev = 0.0;
+
+    public final Mass carriageMass = Kilograms.of(5.0);
+    public final Distance drumRadius = Meters.of(0.05);
+    public final Distance elevatorStartingHeight = Meters.of(0.0);
   }
 }

--- a/examples/ElevatorConstants.java
+++ b/examples/ElevatorConstants.java
@@ -1,7 +1,7 @@
 package frc.robot.subsystems.scoring; // NOTE: This should be changed if you keep your constants in a separate package from your code
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.KilogramSquareMeters;
+import static edu.wpi.first.units.Units.Kilograms;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Radians;
 
@@ -13,7 +13,7 @@ import coppercore.parameter_tools.path_provider.EnvironmentHandler;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
-import edu.wpi.first.units.measure.MomentOfInertia;
+import edu.wpi.first.units.measure.Mass;
 import edu.wpi.first.wpilibj.Filesystem;
 
 
@@ -81,6 +81,8 @@ public final class ElevatorConstants {
   public final Current elevatorStatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
   public final Double elevatorReduction = 1.0; // TODO: Replace placeholder reduction
+
+  public final Double elevatorHeightPerElevatorEncoderRotationMeters = 0.1;
   public final Distance elevatorMinMinHeight = Meters.of(0.0); // TODO: Replace placeholder constraints
   public final Distance elevatorMaxMaxHeight = Meters.of(1.0);
   public static final class Sim {

--- a/examples/ElevatorIO.java
+++ b/examples/ElevatorIO.java
@@ -45,6 +45,8 @@ public interface ElevatorIO {
     public MutCurrent followerMotorSupplyCurrent = Amps.mutable(0.0);
     
 
+    public boolean elevatorEncoderConnected = false;
+
     /** Current position of the elevatorEncoder. This measures total rotation since power on, not absolute position */
     public MutAngle elevatorEncoderPos = Rotations.mutable(0.0);
 
@@ -73,7 +75,7 @@ public interface ElevatorIO {
     /** Are the motors currently disabled in software? */
     public boolean motorsDisabled = false;
 
-    /** The current output mode of the elevator */
+    /** The current output mode of the Elevator */
     public ElevatorOutputMode outputMode = ElevatorOutputMode.ClosedLoop;
 
     /** The voltage currently applied to the motors */
@@ -109,13 +111,13 @@ public interface ElevatorIO {
    * Set the goal position of elevatorEncoder which the Elevator will control to when it is not in
    * override mode
    */
-  public void setelevatorEncoderGoalPos(Angle goalPos);
+  public void setElevatorEncoderGoalPos(Angle goalPos);
 
   /**
    * Set the position of the elevatorEncoder. This position is separate from absolute position and
    * can track multiple rotations.
    */
-  public void setPosition(Angle newAngle);
+  public void setElevatorEncoderPosition(Angle newAngle);
 
   /**
    * Set the override voltage for the Elevator when in Voltage output mode
@@ -136,7 +138,7 @@ public interface ElevatorIO {
    */
   public void setOutputMode(ElevatorOutputMode mode);
 
-  /** Update PID gains for the elevator */
+  /** Update PID gains for the Elevator */
   public void setPID(double p, double i, double d);
 
   /** Set profile constraints to be sent to Motion Magic Expo */

--- a/examples/ElevatorIOSim.java
+++ b/examples/ElevatorIOSim.java
@@ -16,6 +16,8 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
 import frc.robot.constants.JsonConstants;
 import frc.robot.constants.SimConstants;
@@ -62,8 +64,7 @@ public class ElevatorIOSim extends ElevatorIOTalonFX {
 
     Angle elevatorEncoderAngle = Rotations.of(elevatorHeight.in(Meters) / heightPerRotation);
 
-    Angle motorAngle =
-        Rotations.of(elevatorEncoderAngle.times(ElevatorConstants.synced.getObject().elevatorReduction));
+    Angle motorAngle = elevatorEncoderAngle.times(ElevatorConstants.synced.getObject().elevatorReduction);
 
     // Convert Elevator velocity (m/s) into angular velocity of elevatorEncoder
     // by dividing by height per rotation: (m/s) / (m/rot) = rot/s
@@ -92,6 +93,8 @@ public class ElevatorIOSim extends ElevatorIOTalonFX {
     followerMotorSimState.setSupplyVoltage(RobotController.getBatteryVoltage());
 
     elevatorSim.setInputVoltage(leadMotorSimState.getMotorVoltage());
+
+    elevatorSim.update(SimConstants.simDeltaTime.in(Seconds));
   }
 
   @Override

--- a/examples/ElevatorIOSim.java
+++ b/examples/ElevatorIOSim.java
@@ -1,0 +1,103 @@
+package frc.robot.subsystems.scoring;
+
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Kilograms;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
+
+import com.ctre.phoenix6.sim.CANcoderSimState;
+import com.ctre.phoenix6.sim.ChassisReference;
+import com.ctre.phoenix6.sim.TalonFXSimState;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.ElevatorSim;
+import frc.robot.constants.JsonConstants;
+import frc.robot.constants.SimConstants;
+import org.littletonrobotics.junction.Logger;
+
+public class ElevatorIOSim extends ElevatorIOTalonFX {
+  CANcoderSimState elevatorEncoderSimState = elevatorEncoder.getSimState();
+
+  TalonFXSimState leadMotorSimState = leadMotor.getSimState();
+  TalonFXSimState followerMotorSimState = followerMotor.getSimState();
+
+    private final ElevatorSim elevatorSim =
+      new ElevatorSim(
+          DCMotor.getKrakenX60Foc(2),
+          ElevatorConstants.synced.getObject().elevatorReduction,
+          ElevatorConstants.Sim.synced.getObject().carriageMass.in(Kilograms),
+          ElevatorConstants.Sim.synced.getObject().drumRadius.in(Meters),
+          ElevatorConstants.synced.getObject().elevatorMinMinHeight.in(Meters),
+          ElevatorConstants.synced.getObject().elevatorMaxMaxHeight.in(Meters),
+          true,
+          ElevatorConstants.Sim.synced.getObject().elevatorStartingHeight.in(Meters),
+          ElevatorConstants.Sim.synced.getObject().positionStdDev,
+          ElevatorConstants.Sim.synced.getObject().velocityStdDev);
+
+  public ElevatorIOSim() {
+    super();
+
+    elevatorEncoderSimState.Orientation = ChassisReference.Clockwise_Positive;
+
+    // Initialize sim state so that the first periodic runs with accurate data
+    updateSimState();
+  }
+
+  private void updateSimState() {
+    // Alias that JSON constant here for easier reuse in this method
+    final double heightPerRotation = ElevatorConstants.synced.getObject().elevatorHeightPerElevatorEncoderRotationMeters;
+
+    Distance elevatorHeight = Meters.of(elevatorSim.getPositionMeters());
+    LinearVelocity elevatorVelocity = MetersPerSecond.of(elevatorSim.getVelocityMetersPerSecond());
+
+    Logger.recordOutput("elevator/simElevatorHeightMeters", elevatorHeight.in(Meters));
+    Logger.recordOutput(
+        "elevator/simElevatorVelocityMetersPerSec", elevatorVelocity.in(MetersPerSecond));
+
+    Angle elevatorEncoderAngle = Rotations.of(elevatorHeight.in(Meters) / heightPerRotation);
+
+    Angle motorAngle =
+        Rotations.of(elevatorEncoderAngle.times(ElevatorConstants.synced.getObject().elevatorReduction));
+
+    // Convert Elevator velocity (m/s) into angular velocity of elevatorEncoder
+    // by dividing by height per rotation: (m/s) / (m/rot) = rot/s
+    
+    AngularVelocity elevatorEncoderVelocity =
+        RotationsPerSecond.of(
+            elevatorVelocity.in(MetersPerSecond)
+                / heightPerRotation);
+
+    // For motors, multiply encoder velocity by Elevator reduction, because the motors
+    // will spin [reduction] times as many times as spool.
+    // .times(ElevatorConstants.synced.getObject().elevatorReduction);
+    AngularVelocity motorVelocity =
+        elevatorEncoderVelocity.times(ElevatorConstants.synced.getObject().elevatorReduction);
+    // TODO: Find out if/why sim breaks when multiplying motor velocity by motor reduction
+
+    elevatorEncoderSimState.setRawPosition(elevatorEncoderAngle);
+    elevatorEncoderSimState.setVelocity(elevatorEncoderVelocity);
+
+    leadMotorSimState.setRawRotorPosition(motorAngle);
+    leadMotorSimState.setRotorVelocity(motorVelocity);
+    leadMotorSimState.setSupplyVoltage(RobotController.getBatteryVoltage());
+
+    followerMotorSimState.setRawRotorPosition(motorAngle);
+    followerMotorSimState.setRotorVelocity(motorVelocity);
+    followerMotorSimState.setSupplyVoltage(RobotController.getBatteryVoltage());
+
+    elevatorSim.setInputVoltage(leadMotorSimState.getMotorVoltage());
+  }
+
+  @Override
+  public void updateInputs(ElevatorInputs inputs) {
+    updateSimState();
+
+    super.updateInputs(inputs);
+  }
+}

--- a/examples/ElevatorMechanism.java
+++ b/examples/ElevatorMechanism.java
@@ -1,0 +1,320 @@
+package frc.robot.subsystems.scoring;
+
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Volts;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
+
+import coppercore.parameter_tools.LoggedTunableNumber;
+import coppercore.wpilib_interface.UnitUtils;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.MutDistance;
+import edu.wpi.first.units.measure.LinearVelocity;
+import frc.robot.subsystems.scoring.ElevatorIO.ElevatorOutputMode;
+import org.littletonrobotics.junction.Logger;
+
+/**
+ * A Mechanism to manage the Elevator
+ *
+ * <ul>
+ *   <li>Uses closed-loop TorqueCurrentFOC control
+ */
+public class ElevatorMechanism {
+  ElevatorIO io;
+  ElevatorInputsAutoLogged inputs = new ElevatorInputsAutoLogged();
+  ElevatorOutputsAutoLogged outputs = new ElevatorOutputsAutoLogged();
+
+  MutDistance goalHeight = Rotations.mutable(0.0);
+  MutDistance clampedGoalHeight = Rotations.mutable(0.0);
+
+  MutDistance minDistance = ElevatorConstants.synced.getObject().elevatorMinMinDistance.mutableCopy();
+  MutDistance maxDistance = ElevatorConstants.synced.getObject().elevatorMaxMaxDistance.mutableCopy();
+
+  LoggedTunableNumber elevatorkP;
+  LoggedTunableNumber elevatorkI;
+  LoggedTunableNumber elevatorkD;
+
+  LoggedTunableNumber elevatorkS;
+  LoggedTunableNumber elevatorkV;
+  LoggedTunableNumber elevatorkA;
+  LoggedTunableNumber elevatorkG;
+
+  LoggedTunableNumber elevatorCruiseVelocity;
+  LoggedTunableNumber elevatorExpokV;
+  LoggedTunableNumber elevatorExpokA;
+
+  LoggedTunableNumber elevatorTuningSetpointRotations;
+  LoggedTunableNumber elevatorTuningOverrideVolts;
+
+  public ElevatorMechanism(ElevatorIO io) {
+    elevatorkP =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkP", ElevatorConstants.synced.getObject().elevatorKP);
+    elevatorkI =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkI", ElevatorConstants.synced.getObject().elevatorKI);
+    elevatorkD =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkD", ElevatorConstants.synced.getObject().elevatorKD);
+
+    elevatorkS =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkS", ElevatorConstants.synced.getObject().elevatorKS);
+    elevatorkV =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkV", ElevatorConstants.synced.getObject().elevatorKV);
+    elevatorkA =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkA", ElevatorConstants.synced.getObject().elevatorKA);
+    elevatorkG =
+        new LoggedTunableNumber("ElevatorTunables/elevatorkG", ElevatorConstants.synced.getObject().elevatorKG);
+
+    elevatorCruiseVelocity =
+        new LoggedTunableNumber(
+            "ElevatorTunables/elevatorCruiseVelocity",
+            ElevatorConstants.synced.getObject().elevatorAngularCruiseVelocityRotationsPerSecond);
+    elevatorExpokV =
+        new LoggedTunableNumber(
+            "ElevatorTunables/elevatorExpokV", ElevatorConstants.synced.getObject().elevatorMotionMagicExpo_kV);
+    elevatorExpokA =
+        new LoggedTunableNumber(
+            "ElevatorTunables/elevatorExpokA", ElevatorConstants.synced.getObject().elevatorMotionMagicExpo_kA);
+
+    elevatorTuningSetpointRotations =
+        new LoggedTunableNumber("ElevatorTunables/elevatorTuningSetpointRotations", 0.0);
+    elevatorTuningOverrideVolts =
+        new LoggedTunableNumber("ElevatorTunables/elevatorTuningOverrideVolts", 0.0);
+
+    this.io = io;
+  }
+
+  /**
+   * Runs periodically when the robot is enabled
+   *
+   * <p>Does NOT run automatically! Must be called by the subsystem
+   */
+  public void periodic() {
+    sendGoalHeightToIO();
+
+    io.updateInputs(inputs);
+    io.applyOutputs(outputs);
+
+    Logger.processInputs("Elevator/inputs", inputs);
+    Logger.processInputs("Elevator/outputs", outputs);
+  }
+
+  public void setBrakeMode(boolean brake) {
+    io.setBrakeMode(brake);
+  }
+
+  /** This method must be called from the subsystem's test periodic! */
+  public void testPeriodic() {
+    if (false) { // TODO: Replace placeholder test if ElevatorTuning mode is active
+      // switch (TestModeManager.getTestMode()) {
+      // case ElevatorClosedLoopTuning:
+        io.setOutputMode(ElevatorOutputMode.ClosedLoop);
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (pid) -> {
+              io.setPID(pid[0], pid[1], pid[2]);
+            },
+            elevatorkP,
+            elevatorkI,
+            elevatorkD);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (ff) -> {
+              io.setFF(ff[0], ff[1], ff[2], ff[3]);
+            },
+            elevatorkS,
+            elevatorkV,
+            elevatorkA,
+            elevatorkG);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (maxProfile) -> {
+              io.setMaxProfile(
+                  RadiansPerSecond.of(0.0),
+                  VoltsPerRadianPerSecondSquared.ofNative(maxProfile[0]),
+                  VoltsPerRadianPerSecond.ofNative(maxProfile[1]));
+            },
+            elevatorExpokA,
+            elevatorExpokV);
+
+        LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              setGoalDistance(Rotations.of(setpoint[0]));
+            },
+            elevatorTuningSetpointRotations);
+      /*  case ElevatorVoltageTuning:
+          LoggedTunableNumber.ifChanged(
+            hashCode(),
+            (setpoint) -> {
+              io.setOverrideVoltage(Volts.of(setpoint[0]));
+            },
+            elevatorTuningOverrideVolts);
+          io.setOverrideMode(true);
+          break;
+        }
+        */
+    }
+  }
+
+  public void sendGoalHeightToIO() {
+    updateClampedGoalHeight();
+    // Convert goal height to encoder rotations
+    Angle elevatorEncoderGoalAngle = elevatorHeightToElevatorEncoderAngle(clampedGoalHeight);
+
+    io.setElevatorEncoderGoalPos(elevatorEncoderGoalAngle);
+  }
+
+  /**
+   * Based on the bounds previously set, clamp the last set goal height to be between the bounds.
+   *
+   * <p>If the goal height is outside of the bounds and the bounds are expanded, this function will
+   * still behave as expected, as the mechanism remembers its unclamped goal height and will attempt
+   * to get there once it is allowed.
+   */
+  private void updateClampedGoalHeight() {
+    clampedGoalHeight.mut_replace(UnitUtils.clampMeasure(goalDistance, minDistance, maxDistance));
+
+    Logger.recordOutput("Elevator/clampedGoalHeight", clampedGoalHeight);
+  }
+
+  /**
+   * Set the goal angle the elevator will to control about.
+   *
+   * <p>This goal angle will be clamped by the allowed range of motion
+   *
+   * @param goalDistance The new goal angle
+   */
+  public void setGoalDistance(Distance goalDistance) {
+    this.goalDistance.mut_replace(goalDistance);
+
+    Logger.recordOutput("Elevator/goalDistance", goalDistance);
+  }
+  /**
+   * Sets the minimum and maximum allowed heights that the elevator may target.
+   *
+   * <p>When not in override mode, the goal height of the elevator will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal height is
+   * clamped to be within the new bounds.
+   *
+   * @param minHeight The minimum angle, which will be clamped between elevatorMinMinDistance and
+   *     elevatorMaxMaxDistance before being applied
+   * @param maxHeight The maximum angle, which will be clamped between elevatorMinMinDistance and
+   *     elevatorMaxMaxDistance before being applied
+   */
+  public void setAllowedRangeOfMotion(Distance minHeight, Distance maxHeight) {
+    setMinHeight(minDistance);
+    setMaxHeight(maxDistance);
+  }
+
+  /**
+   * Sets the minimum allowed angle that the elevator may target.
+   *
+   * <p>When not in override mode, the goal height of the elevator will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal height is
+   * clamped to be within the new bounds.
+   *
+   * @param minHeight The minimum angle, which will be clamped between elevatorMinMinHeight and
+   *     elevatorMaxMaxHeight before being applied
+   */
+  public void setMinHeight(Distance minHeight) {
+    this.minDistance.mut_replace(
+        UnitUtils.clampMeasure(
+            minDistance,
+            ElevatorConstants.synced.getObject().elevatorMinMinHeight,
+            ElevatorConstants.synced.getObject().elevatorMaxMaxHeight));
+
+    Logger.recordOutput("Elevator/minHeight", minHeight);
+  }
+
+  /**
+   * Sets the maximum allowed angle that the elevator may target.
+   *
+   * <p>When not in override mode, the goal height of the elevator will be clamped to be between these
+   * values before it is sent to the IO. When these clamps change, the original goal angle is
+   * clamped to be within the new bounds.
+   *
+   * @param maxHeight The maximum angle, which will be clamped between elevatorMinMinHeight and
+   *     elevatorMaxMaxHeight before being applied
+   */
+  public void setMaxHeight(Distance maxHeight) {
+    this.maxHeight.mut_replace(
+        UnitUtils.clampMeasure(
+            maxHeight,
+            ElevatorConstants.synced.getObject().elevatorMaxMaxHeight,
+            ElevatorConstants.synced.getObject().elevatorMaxMaxHeight));
+
+    Logger.recordOutput("Elevator/maxHeight", maxHeight);
+  }
+
+  /**
+   * Get the current height of the elevator
+   *
+   * @return
+   */
+  public Distance getElevatorHeight() {
+  }
+
+  /**
+   * Get the current velocity of the elevator
+   *
+   * @return The current velocity of the elevator, according to the elevatorEncoder
+   */
+  public LinearVelocity getElevatorVelocity() {
+    return inputs.elevatorEncoderVel;
+  }
+
+  /**
+   * Check whether or not the elevatorEncoder is currently connected.
+   *
+   * <p>"Connected" means that last time the position and velocity status signals were refreshed, the status code
+   * was OK
+   *
+   * @return True if connected, false if disconnected
+   */
+  public boolean isElevatorEncoderConnected() {
+    return inputs.elevatorEncoderConnected;
+  }
+
+  /**
+   * Get a reference to the elevator's IO. This should be used to update PID, motion profile, and feed
+   * forward gains, and to set brake mode/disable motors. This method exists to avoid the need to
+   * duplicate all of these functions between the mechanism and the IO.
+   *
+   * @return the elevator mechanism's IO
+   */
+  public ElevatorIO getIO() {
+    return io;
+  }
+
+  /** Set whether or not the motor on the elevator should be disabled */
+  public void setMotorsDisabled(boolean disabled) {
+    io.setMotorsDisabled(disabled);
+  }
+
+  /** Get the current unclamped goal height of the elevator */
+  public Height getElevatorGoalHeight() {
+    return goalHeight;
+  }
+
+  /**
+   * Convert an angle of the elevatorEncoder into Elevator height
+   *
+   * @param elevatorEncoderAngle The encoder angle to convert
+   * @return How much the Elevator would move if the elevatorEncoder were rotated by elevatorEncoderAngle
+   */
+  public Distance elevatorEncoderAngleToElevatorHeight(Angle elevatorEncoderAngle) {
+    return Meters.of(elevatorEncoderAngle.in(Rotations) * ElevatorConstants.synced.getObject().elevatorHeightPerElevatorEncoderRotationMeters);
+  }
+
+  /**
+   * Convert Elevator height into elevatorEncoder angle
+   *
+   * @param ElevatorHeight The distance of the Elevator to convert
+   * @return How much the elevatorEncoder would rotate if the Elevator were moved by ElevatorHeight
+   */
+   public Angle elevatorHeightToElevatorEncoderAngle(Distance elevatorHeight) {
+    return Rotations.of(elevatorHeight.in(Meters) / ElevatorConstants.synced.getObject().elevatorHeightPerElevatorEncoderRotationMeters);
+   }
+}

--- a/examples/WristConstants.java
+++ b/examples/WristConstants.java
@@ -4,6 +4,7 @@ import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Radians;
+import static edu.wpi.first.units.Units.Rotations;
 
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import coppercore.parameter_tools.json.JSONExclude;
@@ -69,16 +70,17 @@ public final class WristConstants {
    * kV results in the maximum velocity of the system. Therefore, a higher profile kV results in a
    * lower profile velocity.
   */
-  public final Double wristExpo_kV_raw = 0.0;
+  public final Double wristMotionMagicExpo_kV = 0.0;
 
   /*
    * The Motion Magic Expo kA, measured in Volts per Radian per Second Squared, but represented as a double so it can be synced by JSONSync
   */
-  public final Double wristExpo_kA_raw = 0.0;
+  public final Double wristMotionMagicExpo_kA = 0.0;
 
   public final Current wristStatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
   public final Double wristReduction = 1.0; // TODO: Replace placeholder reduction
+
   public final Angle wristMinMinAngle = Rotations.of(0.0); // TODO: Replace placeholder constraints
   public final Angle wristMaxMaxAngle = Rotations.of(1.0);
   public static final class Sim {

--- a/examples/WristIO.java
+++ b/examples/WristIO.java
@@ -73,6 +73,9 @@ public interface WristIO {
     /** The voltage currently applied to the motors */
     public MutVoltage wristAppliedVolts = Volts.mutable(0.0);
 
+    /** The current closed-loop output from Motion Magic */
+    public double wristClosedLoopOutput = 0.0;
+
     /** Contribution of the p-term to motor output */
     public MutVoltage pContrib = Volts.mutable(0.0);
 

--- a/examples/WristIOTalonFX.java
+++ b/examples/WristIOTalonFX.java
@@ -117,21 +117,21 @@ public class WristIOTalonFX implements WristIO {
             .withSlot0(
                 new Slot0Configs()
                     .withGravityType(GravityTypeValue.Arm_Cosine)
-                    .withKS(WristConstants.synced.getObject().wristkS)
-                    .withKV(WristConstants.synced.getObject().wristkV)
-                    .withKA(WristConstants.synced.getObject().wristkA)
-                    .withKG(WristConstants.synced.getObject().wristkG)
-                    .withKP(WristConstants.synced.getObject().wristkP)
-                    .withKI(WristConstants.synced.getObject().wristkI)
-                    .withKD(WristConstants.synced.getObject().wristkD))
+                    .withKS(WristConstants.synced.getObject().wristKS)
+                    .withKV(WristConstants.synced.getObject().wristKV)
+                    .withKA(WristConstants.synced.getObject().wristKA)
+                    .withKG(WristConstants.synced.getObject().wristKG)
+                    .withKP(WristConstants.synced.getObject().wristKP)
+                    .withKI(WristConstants.synced.getObject().wristKI)
+                    .withKD(WristConstants.synced.getObject().wristKD))
             .withMotionMagic(
                 new MotionMagicConfigs()
                     .withMotionMagicCruiseVelocity(
                         WristConstants.synced.getObject().wristAngularCruiseVelocityRotationsPerSecond)
                     .withMotionMagicExpo_kA(
-                        WristConstants.synced.getObject().wristExpo_kA_raw)
+                        WristConstants.synced.getObject().wristMotionMagicExpo_kA)
                     .withMotionMagicExpo_kV(
-                        WristConstants.synced.getObject().wristExpo_kV_raw));
+                        WristConstants.synced.getObject().wristMotionMagicExpo_kV));
 
     // Apply talonFX config to motor
     wristMotor.getConfigurator().apply(talonFXConfigs);
@@ -186,7 +186,8 @@ public class WristIOTalonFX implements WristIO {
               "wrist/referenceSlope",
               wristMotor.getClosedLoopReferenceSlope().getValueAsDouble());
           outputs.wristAppliedVolts.mut_replace(
-              Volts.of(wristMotor.getClosedLoopOutput().getValueAsDouble()));
+              wristMotor.getMotorVoltage().getValue());
+          outputs.wristClosedLoopOutput = wristMotor.getClosedLoopOutput().getValueAsDouble();
           outputs.pContrib.mut_replace(
               Volts.of(wristMotor.getClosedLoopProportionalOutput().getValueAsDouble()));
           outputs.iContrib.mut_replace(

--- a/src/robotvibecoder_aidnem/subcommands/generate.py
+++ b/src/robotvibecoder_aidnem/subcommands/generate.py
@@ -33,10 +33,8 @@ def generate(args: Namespace) -> None:
 
     env = generate_env()
 
-    if config.kind != MechanismKind.Arm:
-        raise NotImplementedError(
-            "Mechanism kinds beside Arm are not implemented yet :("
-        )
+    if config.kind == MechanismKind.Flywheel:
+        raise NotImplementedError("Flywheel Mechanisms are not implemented yet :(")
 
     template_to_output_map: dict[str, str] = {
         "Mechanism.java.j2": "{name}Mechanism.java",

--- a/src/robotvibecoder_aidnem/templates/ElevatorSim.java.j2
+++ b/src/robotvibecoder_aidnem/templates/ElevatorSim.java.j2
@@ -1,0 +1,67 @@
+{% extends 'MechanismIOSim.java.j2' %}
+{%- block unit_imports %}
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Kilograms;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
+{% endblock %}
+{%- block sim_import %}
+import edu.wpi.first.wpilibj.simulation.ElevatorSim;
+{%- endblock %}
+{%- block sim_declaration %}
+    private final ElevatorSim {{ name|lowerfirst }}Sim =
+      new ElevatorSim(
+          DCMotor.getKrakenX60Foc({{ motors|length }}),
+          {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Reduction,
+          {{ name }}Constants.Sim.synced.getObject().carriageMass.in(Kilograms),
+          {{ name }}Constants.Sim.synced.getObject().drumRadius.in(Meters),
+          {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMinHeight.in(Meters),
+          {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMaxHeight.in(Meters),
+          true,
+          {{ name }}Constants.Sim.synced.getObject().{{ name|lowerfirst }}StartingHeight.in(Meters),
+          {{ name }}Constants.Sim.synced.getObject().positionStdDev,
+          {{ name }}Constants.Sim.synced.getObject().velocityStdDev);
+{%- endblock %}
+{%- block update_sim_state %}
+    // Alias that JSON constant here for easier reuse in this method
+    final double heightPerRotation = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters;
+
+    Distance {{ name|lowerfirst }}Height = Meters.of({{ name|lowerfirst }}Sim.getPositionMeters());
+    LinearVelocity {{ name|lowerfirst }}Velocity = MetersPerSecond.of({{ name|lowerfirst }}Sim.getVelocityMetersPerSecond());
+
+    Logger.recordOutput("{{ name|lowerfirst }}/sim{{ name }}HeightMeters", elevatorHeight.in(Meters));
+    Logger.recordOutput(
+        "{{ name|lowerfirst }}/sim{{ name }}VelocityMetersPerSec", elevatorVelocity.in(MetersPerSecond));
+
+    Angle {{ encoder }}Angle = Rotations.of({{ name|lowerfirst }}Height.in(Meters) / heightPerRotation);
+
+    Angle motorAngle =
+        Rotations.of({{ encoder }}Angle.times({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Reduction));
+
+    // Convert {{ name }} velocity (m/s) into angular velocity of {{ encoder }}
+    // by dividing by height per rotation: (m/s) / (m/rot) = rot/s
+    
+    AngularVelocity {{ encoder }}Velocity =
+        RotationsPerSecond.of(
+            {{ name|lowerfirst }}Velocity.in(MetersPerSecond)
+                / heightPerRotation);
+
+    // For motors, multiply encoder velocity by {{ name }} reduction, because the motors
+    // will spin [reduction] times as many times as spool.
+    // .times(ElevatorConstants.synced.getObject().elevatorReduction);
+    AngularVelocity motorVelocity =
+        {{ encoder }}Velocity.times({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Reduction);
+    // TODO: Find out if/why sim breaks when multiplying motor velocity by motor reduction
+
+    {{ encoder }}SimState.setRawPosition({{ encoder }}Angle);
+    {{ encoder }}SimState.setVelocity({{ encoder }}Velocity);
+{% for motor in motors %}
+    {{ motor }}SimState.setRawRotorPosition(motorAngle);
+    {{ motor }}SimState.setRotorVelocity(motorVelocity);
+    {{ motor }}SimState.setSupplyVoltage(RobotController.getBatteryVoltage());
+{% endfor %}
+    {{ name|lowerfirst }}Sim.setInputVoltage(leadMotorSimState.getMotorVoltage());
+{%- endblock %}

--- a/src/robotvibecoder_aidnem/templates/ElevatorSim.java.j2
+++ b/src/robotvibecoder_aidnem/templates/ElevatorSim.java.j2
@@ -9,6 +9,8 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 {% endblock %}
 {%- block sim_import %}
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
 {%- endblock %}
 {%- block sim_declaration %}
@@ -32,14 +34,13 @@ import edu.wpi.first.wpilibj.simulation.ElevatorSim;
     Distance {{ name|lowerfirst }}Height = Meters.of({{ name|lowerfirst }}Sim.getPositionMeters());
     LinearVelocity {{ name|lowerfirst }}Velocity = MetersPerSecond.of({{ name|lowerfirst }}Sim.getVelocityMetersPerSecond());
 
-    Logger.recordOutput("{{ name|lowerfirst }}/sim{{ name }}HeightMeters", elevatorHeight.in(Meters));
+    Logger.recordOutput("{{ name|lowerfirst }}/sim{{ name }}HeightMeters", {{ name|lowerfirst }}Height.in(Meters));
     Logger.recordOutput(
-        "{{ name|lowerfirst }}/sim{{ name }}VelocityMetersPerSec", elevatorVelocity.in(MetersPerSecond));
+        "{{ name|lowerfirst }}/sim{{ name }}VelocityMetersPerSec", {{ name|lowerfirst }}Velocity.in(MetersPerSecond));
 
     Angle {{ encoder }}Angle = Rotations.of({{ name|lowerfirst }}Height.in(Meters) / heightPerRotation);
 
-    Angle motorAngle =
-        Rotations.of({{ encoder }}Angle.times({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Reduction));
+    Angle motorAngle = {{ encoder }}Angle.times({{ name }}Constants.synced.getObject().{{ name|lowerfirst }}Reduction);
 
     // Convert {{ name }} velocity (m/s) into angular velocity of {{ encoder }}
     // by dividing by height per rotation: (m/s) / (m/rot) = rot/s
@@ -63,5 +64,7 @@ import edu.wpi.first.wpilibj.simulation.ElevatorSim;
     {{ motor }}SimState.setRotorVelocity(motorVelocity);
     {{ motor }}SimState.setSupplyVoltage(RobotController.getBatteryVoltage());
 {% endfor %}
-    {{ name|lowerfirst }}Sim.setInputVoltage(leadMotorSimState.getMotorVoltage());
+    {{ name|lowerfirst }}Sim.setInputVoltage({{ lead_motor }}SimState.getMotorVoltage());
+
+    {{ name|lowerfirst }}Sim.update(SimConstants.simDeltaTime.in(Seconds));
 {%- endblock %}

--- a/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
+++ b/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
@@ -1,6 +1,9 @@
 package frc.robot.{{ package }};
 
 import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.{{ kind|pos_unit }};
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Volts;
 import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
@@ -11,6 +14,9 @@ import coppercore.wpilib_interface.UnitUtils;
 {%-if kind != "Flywheel" %}
 import edu.wpi.first.units.measure.{{ kind|pos_dimension }};
 import edu.wpi.first.units.measure.Mut{{ kind|pos_dimension }};
+{%- endif %}
+{%- if kind == "Elevator" %}
+import edu.wpi.first.units.measure.Angle;
 {%- endif %}
 import edu.wpi.first.units.measure.{{ kind|vel_dimension }};
 import frc.robot.{{ package }}.{{ name }}IO.{{ name }}OutputMode;
@@ -27,13 +33,13 @@ public class {{ name }}Mechanism {
   {{ name }}InputsAutoLogged inputs = new {{ name }}InputsAutoLogged();
   {{ name }}OutputsAutoLogged outputs = new {{ name }}OutputsAutoLogged();
 
-  Mut{{ kind|pos_dimension }} goal{{ kind|goal }} = Rotations.mutable(0.0);
+  Mut{{ kind|pos_dimension }} goal{{ kind|goal }} = {{ kind|pos_unit }}.mutable(0.0);
 {%- if kind != "Flywheel" %}
-  Mut{{ kind|pos_dimension }} clampedGoal{{ kind|goal }} = Rotations.mutable(0.0);
+  Mut{{ kind|pos_dimension }} clampedGoal{{ kind|goal }} = {{ kind|pos_unit }}.mutable(0.0);
 {%- endif %}
 
-  Mut{{ kind|pos_dimension }} min{{ kind|pos_dimension }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMin{{ kind|pos_dimension }}.mutableCopy();
-  Mut{{ kind|pos_dimension }} max{{ kind|pos_dimension }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|pos_dimension }}.mutableCopy();
+  Mut{{ kind|pos_dimension }} min{{ kind|goal }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMin{{ kind|goal }}.mutableCopy();
+  Mut{{ kind|pos_dimension }} max{{ kind|goal }} = {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|goal }}.mutableCopy();
 
   LoggedTunableNumber {{ name|lowerfirst }}kP;
   LoggedTunableNumber {{ name|lowerfirst }}kI;
@@ -145,7 +151,7 @@ public class {{ name }}Mechanism {
         LoggedTunableNumber.ifChanged(
             hashCode(),
             (setpoint) -> {
-              setGoal{{ kind|pos_dimension }}(Rotations.of(setpoint[0]));
+              setGoal{{ kind|goal }}({{ kind|pos_unit }}.of(setpoint[0]));
             },
             {{ name|lowerfirst }}TuningSetpointRotations);
       /*  case {{ name }}VoltageTuning:
@@ -188,23 +194,23 @@ public class {{ name }}Mechanism {
    * to get there once it is allowed.
    */
   private void updateClampedGoal{{ kind|goal }}() {
-    clampedGoal{{ kind|goal }}.mut_replace(UnitUtils.clampMeasure(goal{{ kind|pos_dimension }}, min{{ kind|pos_dimension }}, max{{ kind|pos_dimension }}));
+    clampedGoal{{ kind|goal }}.mut_replace(UnitUtils.clampMeasure(goal{{ kind|goal }}, min{{ kind|goal }}, max{{ kind|goal }}));
 
     Logger.recordOutput("{{ name }}/clampedGoal{{ kind|goal }}", clampedGoal{{ kind|goal }});
   }
 {%- endif %}
 
   /**
-   * Set the goal angle the {{ name|lowerfirst }} will to control about.
+   * Set the goal {{ kind|goal|lowerfirst }} the {{ name|lowerfirst }} will to control to.
    *
-   * <p>This goal angle will be clamped by the allowed range of motion
+   * <p>This goal {{ kind|goal|lowerfirst }} will be clamped by the allowed range of motion
    *
    * @param goal{{ kind|pos_dimension }} The new goal angle
    */
-  public void setGoal{{ kind|pos_dimension }}({{ kind|pos_dimension }} goal{{ kind|pos_dimension }}) {
-    this.goal{{ kind|pos_dimension }}.mut_replace(goal{{ kind|pos_dimension }});
+  public void setGoal{{ kind|goal }}({{ kind|pos_dimension }} goal{{ kind|goal }}) {
+    this.goal{{ kind|goal }}.mut_replace(goal{{ kind|goal }});
 
-    Logger.recordOutput("{{ name }}/goal{{ kind|pos_dimension }}", goal{{ kind|pos_dimension }});
+    Logger.recordOutput("{{ name }}/goal{{ kind|goal }}", goal{{ kind|goal }});
   }
 
 {%- if kind != "Flywheel" %}
@@ -221,8 +227,8 @@ public class {{ name }}Mechanism {
    *     {{ name|lowerfirst }}MaxMax{{ kind|pos_dimension }} before being applied
    */
   public void setAllowedRangeOfMotion({{ kind|pos_dimension }} min{{ kind|goal }}, {{ kind|pos_dimension }} max{{ kind|goal }}) {
-    setMin{{ kind|goal }}(min{{ kind|pos_dimension }});
-    setMax{{ kind|goal }}(max{{ kind|pos_dimension }});
+    setMin{{ kind|goal }}(min{{ kind|goal }});
+    setMax{{ kind|goal }}(max{{ kind|goal }});
   }
 
   /**
@@ -236,9 +242,9 @@ public class {{ name }}Mechanism {
    *     {{ name|lowerfirst }}MaxMax{{ kind|goal }} before being applied
    */
   public void setMin{{ kind|goal }}({{ kind|pos_dimension }} min{{ kind|goal }}) {
-    this.min{{ kind|pos_dimension }}.mut_replace(
+    this.min{{ kind|goal }}.mut_replace(
         UnitUtils.clampMeasure(
-            min{{ kind|pos_dimension }},
+            min{{ kind|goal }},
             {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MinMin{{ kind|goal }},
             {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}MaxMax{{ kind|goal }}));
 
@@ -285,7 +291,12 @@ public class {{ name }}Mechanism {
    * @return The current velocity of the {{ name|lowerfirst }}, according to the {{ encoder }}
    */
   public {{ kind|vel_dimension }} get{{ name }}Velocity() {
+{%- if kind != "Elevator" %}
     return inputs.{{ encoder }}Vel;
+{%- else %}
+  return MetersPerSecond.of(
+    inputs.{{ encoder }}Vel.in(RotationsPerSecond) * {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
+{%- endif%}
   }
 
   /**
@@ -317,7 +328,7 @@ public class {{ name }}Mechanism {
   }
 
   /** Get the current{%if kind != "Flywheel"%} unclamped{% endif %} goal {{ kind|goal|lowerfirst }} of the {{ name|lowerfirst }} */
-  public {{ kind|goal_dimension }} get{{ name }}Goal{{ kind|goal }}() {
+  public {{ kind|goal_dimension }} getGoal{{ kind|goal }}() {
     return goal{{ kind|goal }};
   }
 {%- if kind == "Elevator" %}

--- a/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
+++ b/src/robotvibecoder_aidnem/templates/Mechanism.java.j2
@@ -172,7 +172,7 @@ public class {{ name }}Mechanism {
     // Convert goal height to encoder rotations
     Angle {{ encoder }}GoalAngle = {{ name|lowerfirst }}HeightTo{{ encoder|upperfirst }}Angle(clampedGoal{{ kind|goal }});
 
-    io.set {{ encoder|upperfirst }}GoalPos({{ encoder }}GoalAngle);
+    io.set{{ encoder|upperfirst }}GoalPos({{ encoder }}GoalAngle);
 {%- endif %}
 {%- else %}
     io.set{{ encoder|upperfirst }}GoalSpeed(goal{{ kind|goal }});
@@ -273,7 +273,7 @@ public class {{ name }}Mechanism {
   public {{ kind|pos_dimension }} get{{ name }}{{ kind|goal }}() {
 {%- if kind == "Arm" %}
     return inputs.{{ encoder }}Pos;
-{%- elif kind == "Elevator "%}
+{%- elif kind == "Elevator" %}
     return {{ encoder }}AngleTo{{ name }}Height(inputs.{{ encoder }}Pos);
 {%- endif%}
   }
@@ -329,7 +329,7 @@ public class {{ name }}Mechanism {
    * @return How much the {{ name }} would move if the {{ encoder }} were rotated by {{ encoder }}Angle
    */
   public Distance {{ encoder }}AngleTo{{ name }}Height(Angle {{ encoder }}Angle) {
-    return Meters.of({{ encoder }}Angle.in(Rotations) * {{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
+    return Meters.of({{ encoder }}Angle.in(Rotations) * {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
   }
 
   /**
@@ -339,7 +339,7 @@ public class {{ name }}Mechanism {
    * @return How much the {{ encoder }} would rotate if the {{ name }} were moved by {{ name }}Height
    */
    public Angle {{ name|lowerfirst }}HeightTo{{ encoder|upperfirst }}Angle(Distance {{ name|lowerfirst }}Height) {
-    return Rotations.of({{ name|lowerfirst }}Height.in(Meters) / {{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
+    return Rotations.of({{ name|lowerfirst }}Height.in(Meters) / {{ name }}Constants.synced.getObject().{{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters);
    }
 {%- endif%}
 }

--- a/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
@@ -119,6 +119,10 @@ public final class {{ name }}Constants {
     public final Angle {{ name|lowerfirst }}MaxAngle = Radians.of(1.0);
 
     public final Angle {{ name|lowerfirst }}StartingAngle = Radians.of(0.0);
+{%- elif kind == "Elevator" %}
+    public final Mass carriageMass = Kilograms.of(5.0);
+    public final Distance drumRadius = Meters.of(0.05);
+    public final Distance {{ name|lowerfirst }}StartingHeight = Meters.of(0.0);
 {%- endif %}
   }
 }

--- a/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismConstants.java.j2
@@ -1,7 +1,12 @@
 package frc.robot.{{ package }}; // NOTE: This should be changed if you keep your constants in a separate package from your code
 
 import static edu.wpi.first.units.Units.Amps;
+{%- if kind == "Arm" %}
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
+{%- endif %}
+{%- if kind == "Elevator" %}
+import static edu.wpi.first.units.Units.Kilograms;
+{%- endif %}
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Radians;
 {%- if kind != "Flywheel" and kind|pos_unit != "Meters" %}
@@ -16,7 +21,12 @@ import coppercore.parameter_tools.path_provider.EnvironmentHandler;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
+{%- if kind == "Elevator" %}
+import edu.wpi.first.units.measure.Mass;
+{%- endif %}
+{%- if kind == "Arm" %}
 import edu.wpi.first.units.measure.MomentOfInertia;
+{%- endif %}
 import edu.wpi.first.wpilibj.Filesystem;
 
 
@@ -89,7 +99,9 @@ public final class {{ name }}Constants {
   public final Current {{ name|lowerfirst }}StatorCurrentLimit = Amps.of(80.0); // TODO: Replace placeholder current limit
 
   public final Double {{ name|lowerfirst }}Reduction = 1.0; // TODO: Replace placeholder reduction
-
+{% if kind == "Elevator" %}
+  public final Double {{ name|lowerfirst }}HeightPer{{ encoder|upperfirst }}RotationMeters = 0.1;
+{%- endif %}
 {%- if kind != "Flywheel" %}
   public final {{ kind|pos_dimension }} {{ name|lowerfirst }}MinMin{{ kind|goal }} = {{ kind|pos_unit }}.of(0.0); // TODO: Replace placeholder constraints
   public final {{ kind|pos_dimension }} {{ name|lowerfirst }}MaxMax{{ kind|goal }} = {{ kind|pos_unit }}.of(1.0);

--- a/src/robotvibecoder_aidnem/templates/MechanismIO.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismIO.java.j2
@@ -74,6 +74,9 @@ public interface {{ name }}IO {
     /** The voltage currently applied to the motors */
     public MutVoltage {{ name|lowerfirst }}AppliedVolts = Volts.mutable(0.0);
 
+    /** The current closed-loop output from Motion Magic */
+    public double {{ name|lowerfirst }}ClosedLoopOutput = 0.0;
+
     /** Contribution of the p-term to motor output */
     public MutVoltage pContrib = Volts.mutable(0.0);
 

--- a/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
+++ b/src/robotvibecoder_aidnem/templates/MechanismIOTalonFX.java.j2
@@ -205,7 +205,8 @@ public class {{ name }}IOTalonFX implements {{ name }}IO {
               "{{ name|lowerfirst }}/referenceSlope",
               {{ lead_motor }}.getClosedLoopReferenceSlope().getValueAsDouble());
           outputs.{{ name|lowerfirst }}AppliedVolts.mut_replace(
-              Volts.of({{ lead_motor }}.getClosedLoopOutput().getValueAsDouble()));
+              {{ lead_motor }}.getMotorVoltage().getValue());
+          outputs.{{ name|lowerfirst }}ClosedLoopOutput = {{ lead_motor }}.getClosedLoopOutput().getValueAsDouble();
           outputs.pContrib.mut_replace(
               Volts.of({{ lead_motor }}.getClosedLoopProportionalOutput().getValueAsDouble()));
           outputs.iContrib.mut_replace(

--- a/src/robotvibecoder_aidnem/templating.py
+++ b/src/robotvibecoder_aidnem/templating.py
@@ -122,7 +122,7 @@ def goal_dimension(kind: str) -> str:
     if kind == "Arm":
         return "Angle"
     elif kind == "Elevator":
-        return "Height"
+        return "Distance"
     else:
         return "AngularVelocity"
 


### PR DESCRIPTION
As seen in this graph, elevators now work in sim:

![image](https://github.com/user-attachments/assets/f59a6d24-6dd2-480a-9419-eca2b42e2115)

Also adds:

- some fixes to the mechanism template
- Separates closed-loop output from applied volts (previously I had just converted FOC closed-loop's output current into a voltage and output that which was ridiculous)